### PR TITLE
[Loki] Make sure each target uses a bespoke XMOD directory

### DIFF
--- a/src/cloudsc_loki/CMakeLists.txt
+++ b/src/cloudsc_loki/CMakeLists.txt
@@ -12,6 +12,43 @@ ecbuild_add_option( FEATURE CLOUDSC_LOKI
     CONDITION Serialbox_FOUND OR HDF5_FOUND
 )
 
+function( cloudsc_xmod _TARGET )
+
+    if( TARGET clawfc AND ${LOKI_FRONTEND} STREQUAL "omni" )
+
+        # Ugly hack: OMNI needs the xmod-file for cloudsc.F90 to be able to
+        # parse the driver file successfully. However, the scheduler currently
+        # doesn't take this into account and fails when parsing driver before
+        # kernel file.
+        # (Note: the problem vanishes in serial builds as there the C-transpile
+        # target is built first which doesn't use the scheduler and therefore
+        # creates the necessary xmod files for us)
+        # TODO: This can be removed once the scheduler is aware of these dependencies
+        # and parses files in the right order
+
+        set( _TARGET_XMOD_DIR "${CMAKE_CURRENT_BINARY_DIR}/${_TARGET}" )
+        set( _TARGET_XMOD_DIR ${_TARGET_XMOD_DIR} PARENT_SCOPE )
+        file( MAKE_DIRECTORY ${_TARGET_XMOD_DIR} )
+
+        generate_xmod(
+            OUTPUT ${_TARGET_XMOD_DIR}/cloudsc.xml
+            SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/cloudsc.F90
+            XMOD ${_TARGET_XMOD_DIR} ${XMOD_DIR}
+        )
+
+        # Use XML files as dependencies (not xmod) as they are updated by later calls of
+        # F_Front (and thus would trigger new execution rounds)
+        set( _OMNI_DEPENDENCIES ${_TARGET_XMOD_DIR}/cloudsc.xml PARENT_SCOPE )
+
+    else()
+
+        set( _TARGET_XMOD_DIR "" PARENT_SCOPE)
+        set( _OMNI_DEPENDENCIES "" PARENT_SCOPE )
+
+    endif()
+
+endfunction()
+
 if( HAVE_CLOUDSC_LOKI )
 
     ####################################################
@@ -30,38 +67,12 @@ if( HAVE_CLOUDSC_LOKI )
       set( CLOUDSC_DEFINE_STMT_FUNC CLOUDSC_STMT_FUNC )
     endif()
 
-    if( TARGET clawfc AND ${LOKI_FRONTEND} STREQUAL "omni" )
-
-        # Ugly hack: OMNI needs the xmod-file for cloudsc.F90 to be able to
-        # parse the driver file successfully. However, the scheduler currently
-        # doesn't take this into account and fails when parsing driver before
-        # kernel file.
-        # (Note: the problem vanishes in serial builds as there the C-transpile
-        # target is built first which doesn't use the scheduler and therefore
-        # creates the necessary xmod files for us)
-        # TODO: This can be removed once the scheduler is aware of these dependencies
-        # and parses files in the right order
-
-        generate_xmod(
-            OUTPUT ${XMOD_DIR}/cloudsc.xml
-            SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/cloudsc.F90
-            XMOD ${XMOD_DIR}
-        )
-
-        # Use XML files as dependencies (not xmod) as they are updated by later calls of
-        # F_Front (and thus would trigger new execution rounds)
-        set( _OMNI_DEPENDENCIES ${XMOD_DIR}/cloudsc.xml )
-
-    else()
-
-        set( _OMNI_DEPENDENCIES )
-
-    endif()
-
     ####################################################
     ##  Idempotence mode:                             ##
     ##   * Internal "do-nothing" mode for Loki debug  ##
     ####################################################
+
+    cloudsc_xmod( loki-idem )
 
     loki_transform_convert(
         MODE idem FRONTEND ${LOKI_FRONTEND} CPP
@@ -69,7 +80,7 @@ if( HAVE_CLOUDSC_LOKI )
         PATH ${CMAKE_CURRENT_SOURCE_DIR}
         HEADER ${COMMON_MODULE}/yomphyder.F90
         INCLUDE ${COMMON_INCLUDE}
-        XMOD ${XMOD_DIR}
+        XMOD ${_TARGET_XMOD_DIR} ${XMOD_DIR}
         OUTPATH ${CMAKE_CURRENT_BINARY_DIR}/loki-idem
         OUTPUT loki-idem/cloudsc.idem.F90 loki-idem/cloudsc_driver_loki_mod.idem.F90
         DEPENDS cloudsc.F90 cloudsc_driver_loki_mod.F90 ${_OMNI_DEPENDENCIES}
@@ -93,13 +104,15 @@ if( HAVE_CLOUDSC_LOKI )
     ##   * Extract de-vectorized SCA format code      ##
     ####################################################
 
+    cloudsc_xmod( loki-sca )
+
     loki_transform_convert(
         MODE sca FRONTEND ${LOKI_FRONTEND} CPP
         CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/cloudsc_loki.config
         PATH ${CMAKE_CURRENT_SOURCE_DIR}
         HEADER ${COMMON_MODULE}/yomphyder.F90
         INCLUDE ${COMMON_INCLUDE}
-        XMOD ${XMOD_DIR}
+        XMOD ${_TARGET_XMOD_DIR} ${XMOD_DIR}
         OUTPATH ${CMAKE_CURRENT_BINARY_DIR}/loki-sca
         OUTPUT loki-sca/cloudsc.sca.F90 loki-sca/cloudsc_driver_loki_mod.sca.F90
         DEPENDS cloudsc.F90 cloudsc_driver_loki_mod.F90 ${_OMNI_DEPENDENCIES}
@@ -125,13 +138,15 @@ if( HAVE_CLOUDSC_LOKI )
     ####################################################
     if( TARGET clawfc )
 
+        cloudsc_xmod( loki-claw-cpu )
+
         loki_transform_convert(
             MODE claw FRONTEND ${LOKI_FRONTEND} CPP
             CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/cloudsc_loki.config
             PATH ${CMAKE_CURRENT_SOURCE_DIR}
             HEADER ${COMMON_MODULE}/yomphyder.F90
             INCLUDE ${COMMON_INCLUDE}
-            XMOD ${XMOD_DIR}
+            XMOD ${_TARGET_XMOD_DIR} ${XMOD_DIR}
             OUTPATH ${CMAKE_CURRENT_BINARY_DIR}/loki-claw-cpu
             OUTPUT loki-claw-cpu/cloudsc.claw.F90 loki-claw-cpu/cloudsc_driver_loki_mod.claw.F90
             DEPENDS cloudsc.F90 cloudsc_driver_loki_mod.F90 ${_OMNI_DEPENDENCIES}
@@ -143,7 +158,7 @@ if( HAVE_CLOUDSC_LOKI )
             MODEL_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/claw_cloudsc.config
             TARGET cpu DIRECTIVE none
             INCLUDE ${COMMON_INCLUDE}
-            XMOD ${XMOD_DIR}
+            XMOD ${_TARGET_XMOD_DIR} ${XMOD_DIR}
             SOURCE loki-claw-cpu/cloudsc.claw.F90
             OUTPUT loki-claw-cpu/cloudsc.claw.cpu.F90
         )
@@ -151,7 +166,7 @@ if( HAVE_CLOUDSC_LOKI )
             MODEL_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/claw_cloudsc.config
             TARGET cpu DIRECTIVE none
             INCLUDE ${COMMON_INCLUDE}
-            XMOD ${XMOD_DIR}
+            XMOD ${_TARGET_XMOD_DIR} ${XMOD_DIR}
             SOURCE loki-claw-cpu/cloudsc_driver_loki_mod.claw.F90
             OUTPUT loki-claw-cpu/cloudsc_driver_loki_mod.claw.cpu.F90
             DEPENDS loki-claw-cpu/cloudsc.claw.cpu.F90
@@ -177,6 +192,8 @@ if( HAVE_CLOUDSC_LOKI )
     ####################################################
     if( TARGET clawfc )
 
+        cloudsc_xmod( loki-claw-gpu )
+
         # Uses Loki-frontend CPP to switch to statement function variant again,
         # but suppresses inlining of stmt funcs by omitting `--include`
         loki_transform_convert(
@@ -187,7 +204,7 @@ if( HAVE_CLOUDSC_LOKI )
             INCLUDE ${COMMON_INCLUDE}
             DEFINE CLOUDSC_GPU_TIMING ${CLOUDSC_DEFINE_STMT_FUNC}
             DATA_OFFLOAD REMOVE_OPENMP
-            XMOD ${XMOD_DIR}
+            XMOD ${_TARGET_XMOD_DIR} ${XMOD_DIR}
             OUTPATH ${CMAKE_CURRENT_BINARY_DIR}/loki-claw-gpu
             OUTPUT loki-claw-gpu/cloudsc.claw.F90 loki-claw-gpu/cloudsc_driver_loki_mod.claw.F90
             DEPENDS cloudsc.F90 cloudsc_driver_loki_mod.F90 ${_OMNI_DEPENDENCIES}
@@ -197,7 +214,7 @@ if( HAVE_CLOUDSC_LOKI )
             MODEL_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/claw_cloudsc.config
             TARGET gpu DIRECTIVE openacc
             INCLUDE ${COMMON_INCLUDE}
-            XMOD ${XMOD_DIR}
+            XMOD ${_TARGET_XMOD_DIR} ${XMOD_DIR}
             SOURCE loki-claw-gpu/cloudsc.claw.F90
             OUTPUT loki-claw-gpu/cloudsc.claw.gpu.F90
         )
@@ -205,7 +222,7 @@ if( HAVE_CLOUDSC_LOKI )
             MODEL_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/claw_cloudsc.config
             TARGET gpu DIRECTIVE openacc
             INCLUDE ${COMMON_INCLUDE}
-            XMOD ${XMOD_DIR}
+            XMOD ${_TARGET_XMOD_DIR} ${XMOD_DIR}
             SOURCE loki-claw-gpu/cloudsc_driver_loki_mod.claw.F90
             OUTPUT loki-claw-gpu/cloudsc_driver_loki_mod.claw.gpu.F90
             DEPENDS loki-claw-gpu/cloudsc.claw.gpu.F90
@@ -236,6 +253,8 @@ if( HAVE_CLOUDSC_LOKI )
     ##   * Invokes compute kernel as `!$acc vector`   ##
     ####################################################
 
+    cloudsc_xmod( loki-scc )
+
     loki_transform_convert(
         MODE scc FRONTEND ${LOKI_FRONTEND} CPP
         CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/cloudsc_loki.config
@@ -244,7 +263,7 @@ if( HAVE_CLOUDSC_LOKI )
         INCLUDE ${COMMON_INCLUDE}
         DEFINE CLOUDSC_GPU_TIMING ${CLOUDSC_DEFINE_STMT_FUNC}
         DATA_OFFLOAD REMOVE_OPENMP
-        XMOD ${XMOD_DIR}
+        XMOD ${_TARGET_XMOD_DIR} ${XMOD_DIR}
         OUTPATH ${CMAKE_CURRENT_BINARY_DIR}/loki-scc
         OUTPUT loki-scc/cloudsc.scc.F90 loki-scc/cloudsc_driver_loki_mod.scc.F90
         DEPENDS cloudsc.F90 cloudsc_driver_loki_mod.F90 ${_OMNI_DEPENDENCIES}
@@ -275,6 +294,8 @@ if( HAVE_CLOUDSC_LOKI )
     ##   * Temporary arrays hoisted to driver         ##
     ####################################################
 
+    cloudsc_xmod( loki-scc-hoist )
+
     loki_transform_convert(
         MODE scc-hoist FRONTEND ${LOKI_FRONTEND} CPP
         CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/cloudsc_loki.config
@@ -283,7 +304,7 @@ if( HAVE_CLOUDSC_LOKI )
         INCLUDE ${COMMON_INCLUDE}
         DEFINE CLOUDSC_GPU_TIMING ${CLOUDSC_DEFINE_STMT_FUNC}
         DATA_OFFLOAD REMOVE_OPENMP
-        XMOD ${XMOD_DIR}
+        XMOD ${_TARGET_XMOD_DIR} ${XMOD_DIR}
         OUTPATH ${CMAKE_CURRENT_BINARY_DIR}/loki-scc-hoist
         OUTPUT
             loki-scc-hoist/cloudsc.scc_hoist.F90
@@ -313,6 +334,8 @@ if( HAVE_CLOUDSC_LOKI )
     # C-transpilation mode for generating vectorized C host code (experimental!)
     ##############################################################################
 
+    cloudsc_xmod( loki-c )
+
     loki_transform_transpile(
         FRONTEND ${LOKI_FRONTEND} CPP
         HEADER
@@ -326,7 +349,7 @@ if( HAVE_CLOUDSC_LOKI )
         DRIVER ${CMAKE_CURRENT_SOURCE_DIR}/cloudsc_driver_loki_mod.F90
         SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/cloudsc.F90
         INCLUDE ${COMMON_INCLUDE}
-        XMOD ${XMOD_DIR}
+        XMOD ${_TARGET_XMOD_DIR} ${XMOD_DIR}
         OUTPATH ${CMAKE_CURRENT_BINARY_DIR}/loki-c
         OUTPUT
             loki-c/cloudsc_driver_loki_mod.c.F90


### PR DESCRIPTION
My last attempt at fixing these race conditions did not reach far enough for OMNI.
This makes now sure that each target uses the target's bin-directory to store newly generated xmods, thus avoiding the issue in parallel builds.