### PR TITLE
Validate results for targets in Github actions

### DIFF
--- a/.github/scripts/run-targets.sh
+++ b/.github/scripts/run-targets.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+exit_code=0
+
+#
+# Run each of the binaries using default arguments and validate exit codes
+#
+
+for target in $(ls build/bin)
+do
+  if [[ "$mpi_flag" == "--with-mpi" ]]
+  then
+    # Two ranks with one thread each
+    mpirun -np 2 bin/$target 1
+  else
+    # Two threads
+    bin/$target 2
+  fi
+  exit_code=$((exit_code + $?))
+done
+
+exit $exit_code

--- a/.github/scripts/run-targets.sh
+++ b/.github/scripts/run-targets.sh
@@ -5,22 +5,31 @@ set -x
 # These targets don't have an MPI-parallel driver routine
 non_mpi_targets=(dwarf-P-cloudMicrophysics-IFSScheme dwarf-cloudsc-c)
 
+# These targets currently cause issues and are therefore not tested
+skipped_targets=(dwarf-cloudsc-gpu-claw)
+
 exit_code=0
 cd build
 
 #
-# Run each of the binaries using default arguments and validate exit codes
+# Run each of the binaries with default NPROMA and validate exit codes
 #
 
 for target in $(ls bin)
 do
+  # Skip some targets
+  if [[ " ${skipped_targets[*]} " =~ " $target " ]]
+  then
+    continue
+  fi
+
   if [[ "$mpi_flag" == "--with-mpi" && ! " ${non_mpi_targets[*]} " =~ " $target " ]]
   then
     # Two ranks with one thread each, default NPROMA
     mpirun -np 2 bin/$target 1 100
   else
-    # Two threads, default NPROMA
-    bin/$target 2 100
+    # Single thread, default NPROMA
+    bin/$target 1 100
   fi
   exit_code=$((exit_code + $?))
 done

--- a/.github/scripts/run-targets.sh
+++ b/.github/scripts/run-targets.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 set -x
 
+# These targets don't have an MPI-parallel driver routine
+non_mpi_targets=(dwarf-P-cloudMicrophysics-IFSScheme dwarf-cloudsc-c)
+
 exit_code=0
 cd build
 
@@ -11,7 +14,7 @@ cd build
 
 for target in $(ls bin)
 do
-  if [[ "$mpi_flag" == "--with-mpi" ]]
+  if [[ "$mpi_flag" == "--with-mpi" && ! " ${non_mpi_targets[*]} " =~ " $target " ]]
   then
     # Two ranks with one thread each
     mpirun -np 2 bin/$target 1

--- a/.github/scripts/run-targets.sh
+++ b/.github/scripts/run-targets.sh
@@ -16,11 +16,11 @@ for target in $(ls bin)
 do
   if [[ "$mpi_flag" == "--with-mpi" && ! " ${non_mpi_targets[*]} " =~ " $target " ]]
   then
-    # Two ranks with one thread each
-    mpirun -np 2 bin/$target 1
+    # Two ranks with one thread each, default NPROMA
+    mpirun -np 2 bin/$target 1 100
   else
-    # Default arguments
-    bin/$target
+    # Two threads, default NPROMA
+    bin/$target 2 100
   fi
   exit_code=$((exit_code + $?))
 done

--- a/.github/scripts/run-targets.sh
+++ b/.github/scripts/run-targets.sh
@@ -3,20 +3,21 @@ set -euo pipefail
 set -x
 
 exit_code=0
+cd build
 
 #
 # Run each of the binaries using default arguments and validate exit codes
 #
 
-for target in $(ls build/bin)
+for target in $(ls bin)
 do
   if [[ "$mpi_flag" == "--with-mpi" ]]
   then
     # Two ranks with one thread each
     mpirun -np 2 bin/$target 1
   else
-    # Two threads
-    bin/$target 2
+    # Default arguments
+    bin/$target
   fi
   exit_code=$((exit_code + $?))
 done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,3 +67,9 @@ jobs:
           io_library_flag: ${{ matrix.io_library_flag }}
           gpu_flag: ${{ matrix.gpu_flag }}
         run: .github/scripts/verify-targets.sh
+
+      # Run targets
+      - name: Run targets
+        env:
+          mpi_flag: ${{ matrix.mpi_flag }}
+        run: .github/scripts/run-targets.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,8 +68,9 @@ jobs:
           gpu_flag: ${{ matrix.gpu_flag }}
         run: .github/scripts/verify-targets.sh
 
-      # Run targets
+      # Run CPU targets
       - name: Run targets
         env:
           mpi_flag: ${{ matrix.mpi_flag }}
+        if: ${{ matrix.prec_flag == '' && matrix.gpu_flag == '' }}
         run: .github/scripts/run-targets.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,9 +68,10 @@ jobs:
           gpu_flag: ${{ matrix.gpu_flag }}
         run: .github/scripts/verify-targets.sh
 
-      # Run CPU targets
+      # Run double-precision targets
+      # (Mind the exclusions inside the script!)
       - name: Run targets
         env:
           mpi_flag: ${{ matrix.mpi_flag }}
-        if: ${{ matrix.prec_flag == '' && matrix.gpu_flag == '' }}
+        if: ${{ matrix.prec_flag == '' }}
         run: .github/scripts/run-targets.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # dwarf-p-cloudsc
+
+[![license](https://img.shields.io/github/license/ecmwf-ifs/dwarf-p-cloudsc)](https://www.apache.org/licenses/LICENSE-2.0.html)
 [![build](https://github.com/ecmwf-ifs/dwarf-p-cloudsc/actions/workflows/build.yml/badge.svg)](https://github.com/ecmwf-ifs/dwarf-p-cloudsc/actions/workflows/build.yml)
 
 `dwarf-p-cloudsc` is intended to test the CLOUDSC cloud microphysics scheme of the IFS.

--- a/src/cloudsc_gpu/dwarf_cloudsc_gpu.F90
+++ b/src/cloudsc_gpu/dwarf_cloudsc_gpu.F90
@@ -32,7 +32,7 @@ INTEGER(KIND=JPIM) :: IARGS, LENARG, JARG, I
 
 INTEGER(KIND=JPIM) :: NUMOMP   = 1     ! Number of OpenMP threads for this run
 INTEGER(KIND=JPIM) :: NGPTOTG  = 16384 ! Number of grid points (as read from command line)
-INTEGER(KIND=JPIM) :: NPROMA   = 32    ! NPROMA blocking factor (currently active)
+INTEGER(KIND=JPIM) :: NPROMA   = 64   ! NPROMA blocking factor (currently active)
 INTEGER(KIND=JPIM) :: NGPTOT           ! Local number of grid points
 
 TYPE(CLOUDSC_GLOBAL_STATE) :: GLOBAL_STATE


### PR DESCRIPTION
This adds an additional step in the build workflow to validate results for a small set of columns (100) for double precision binaries.

Notably, they currently show very small deviations on Github which aren't present on leap42 with same compiler version. Small enough though to not be flagged by the validation module. Will investigate this on a separate occasion as it is currently not reproducible locally.