### PR TITLE
Test NVHPC in Github actions

### DIFF
--- a/.github/scripts/bootstrap-nvhpc.sh
+++ b/.github/scripts/bootstrap-nvhpc.sh
@@ -24,8 +24,10 @@ curl --location "$url" | tar zx -C "${temporary_files}"
 
 # Build hdf5
 cd "${temporary_files}/hdf5-${hdf5_version}"
-prefix = "${GITHUB_WORKSPACE}/hdf5-install"
+prefix="${GITHUB_WORKSPACE}/hdf5-install"
 mkdir -p "${prefix}"
 ./configure --prefix="${prefix}" --enable-shared --enable-fortran --enable-hl
 make -j
 make install
+
+exit 0

--- a/.github/scripts/bootstrap-nvhpc.sh
+++ b/.github/scripts/bootstrap-nvhpc.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 set -x
 
 nvhpc_version=21.9
-hdf5_version=1.10.8
 
 # Use Atlas' nvhpc installation script
 wget https://raw.githubusercontent.com/ecmwf/atlas/develop/tools/install-nvhpc.sh
@@ -11,23 +10,5 @@ chmod +x install-nvhpc.sh
 
 # Install nvhpc
 ./install-nvhpc.sh --version $nvhpc_version --prefix "${GITHUB_WORKSPACE}/nvhpc-install" --tmpdir "${RUNNER_TEMP}"
-
-# Choose hdf5
-version_parts=($(echo ${hdf5_version} | tr "." "\n"))
-major_version=${version_parts[0]}.${version_parts[1]}
-temporary_files="${RUNNER_TEMP}/hdf5"
-url=https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${major_version}/hdf5-${hdf5_version}/src/hdf5-${hdf5_version}.tar.gz
-
-# Download hdf5
-mkdir -p "${temporary_files}"
-curl --location "$url" | tar zx -C "${temporary_files}"
-
-# Build hdf5
-cd "${temporary_files}/hdf5-${hdf5_version}"
-prefix="${GITHUB_WORKSPACE}/hdf5-install"
-mkdir -p "${prefix}"
-./configure --prefix="${prefix}" --enable-shared --enable-fortran --enable-hl
-make -j
-make install
 
 exit 0

--- a/.github/scripts/bootstrap-nvhpc.sh
+++ b/.github/scripts/bootstrap-nvhpc.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+nvhpc_version=21.9
+hdf5_version=1.10.8
+
+# Use Atlas' nvhpc installation script
+wget https://raw.githubusercontent.com/ecmwf/atlas/develop/tools/install-nvhpc.sh
+chmod +x install-nvhpc.sh
+
+# Install nvhpc
+./install-nvhpc.sh --version $nvhpc_version --prefix "${GITHUB_WORKSPACE}/nvhpc-install" --tmpdir "${RUNNER_TEMP}"
+
+# Choose hdf5
+version_parts=($(echo ${hdf5_version} | tr "." "\n"))
+major_version=${version_parts[0]}.${version_parts[1]}
+temporary_files="${RUNNER_TEMP}/hdf5"
+url=https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${major_version}/hdf5-${hdf5_version}/src/hdf5-${hdf5_version}.tar.gz
+
+# Download hdf5
+mkdir -p "${temporary_files}"
+curl --location "$url" | tar zx -C "${temporary_files}"
+
+# Build hdf5
+cd "${temporary_files}/hdf5-${hdf5_version}"
+prefix = "${GITHUB_WORKSPACE}/hdf5-install"
+mkdir -p "${prefix}"
+./configure --prefix="${prefix}" --enable-shared --enable-fortran --enable-hl
+make -j
+make install

--- a/.github/scripts/install-hdf5.sh
+++ b/.github/scripts/install-hdf5.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+hdf5_version=1.10.8
+
+# Choose hdf5
+version_parts=($(echo ${hdf5_version} | tr "." "\n"))
+major_version=${version_parts[0]}.${version_parts[1]}
+temporary_files="${RUNNER_TEMP}/hdf5"
+url=https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${major_version}/hdf5-${hdf5_version}/src/hdf5-${hdf5_version}.tar.gz
+
+# Download hdf5
+mkdir -p "${temporary_files}"
+curl --location "$url" | tar zx -C "${temporary_files}"
+
+# Build hdf5
+cd "${temporary_files}/hdf5-${hdf5_version}"
+prefix="${GITHUB_WORKSPACE}/hdf5-install"
+mkdir -p "${prefix}"
+./configure --prefix="${prefix}" --enable-shared --enable-fortran --enable-hl
+make -j
+make install
+
+exit 0
+

--- a/.github/scripts/run-targets.sh
+++ b/.github/scripts/run-targets.sh
@@ -8,6 +8,12 @@ non_mpi_targets=(dwarf-P-cloudMicrophysics-IFSScheme dwarf-cloudsc-c)
 # These targets currently cause issues and are therefore not tested
 skipped_targets=(dwarf-cloudsc-gpu-claw)
 
+# Skip GPU targets if built with nvhpc (don't have GPU in test runner)
+if [[ "$arch" == *"nvhpc"* ]]
+then
+  skipped_targets+=(dwarf-cloudsc-gpu-scc dwarf-cloudsc-gpu-scc-hoist)
+fi
+
 exit_code=0
 cd build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,21 +54,21 @@ jobs:
 
       # Install MPI
       - name: Install MPI
-        if: matrix.mpi_flag == "--with-mpi"
+        if: contains( matrix.mpi_flag, 'with-mpi' )
         run: sudo apt-get install libopenmpi-dev
 
       # Install Compiler
       - name: Install nvhpc
-        if: contains(matrix.arch, 'nvhpc')
+        if: contains( matrix.arch, 'nvhpc' )
         run: .github/scripts/bootstrap-nvhpc.sh
 
       # Install HDF5
       - name: Install HDF5
-        if: contains(matrix.arch, 'nvhpc') and matrix.io_library_flag != '--with-serialbox'
+        if: contains( matrix.arch, 'nvhpc' ) && ! contains( matrix.io_library_flag, 'with-serialbox' )
         run: source ${{ matrix.arch }} && .github/scripts/install-hdf5.sh
 
       - name: Install HDF5
-        if: contains(matrix.arch, 'gnu') and matrix.io_library_flag != '--with-serialbox'
+        if: contains( matrix.arch, 'gnu' ) && ! contains( matrix.io_library_flag, 'with-serialbox' )
         run: sudo apt-get install libhdf5-dev
       
       # Check-out dependencies as part of the bundle creation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
       
       - name: Install HDF5 from source
         if: contains( matrix.arch, 'nvhpc' ) && ! contains( matrix.io_library_flag, 'with-serialbox' )
-        run: source arch/${{ matrix.arch }} && .github/scripts/install-hdf5.sh
+        run: source arch/${{ matrix.arch }}/env.sh && .github/scripts/install-hdf5.sh
 
       # Check-out dependencies as part of the bundle creation
       - name: Bundle create

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,12 +52,24 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      # Sets-up environment and installs required packages
-      - name: Environment setup
-        run: |
-          [[ "${{ matrix.mpi_flag }}" == "--with-mpi" ]] && sudo apt install libopenmpi-dev || true
-          [[ "${{ matrix.io_library_flag }}" != "--with-serialbox" ]] && sudo apt install libhdf5-dev || true
-          [[ "${{ matrix.arch }}" == *"nvhpc"* ]] && .github/scripts/bootstrap-nvhpc.sh || true
+      # Install MPI
+      - name: Install MPI
+        if: matrix.mpi_flag == "--with-mpi"
+        run: sudo apt-get install libopenmpi-dev
+
+      # Install Compiler
+      - name: Install nvhpc
+        if: contains(matrix.arch, 'nvhpc')
+        run: .github/scripts/bootstrap-nvhpc.sh
+
+      # Install HDF5
+      - name: Install HDF5
+        if: contains(matrix.arch, 'nvhpc') and matrix.io_library_flag != '--with-serialbox'
+        run: source ${{ matrix.arch }} && .github/scripts/install-hdf5.sh
+
+      - name: Install HDF5
+        if: contains(matrix.arch, 'gnu') and matrix.io_library_flag != '--with-serialbox'
+        run: sudo apt-get install libhdf5-dev
       
       # Check-out dependencies as part of the bundle creation
       - name: Bundle create

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,5 +94,6 @@ jobs:
       - name: Run targets
         env:
           mpi_flag: ${{ matrix.mpi_flag }}
+          arch: ${{ matrix.arch }}
         if: ${{ matrix.prec_flag == '' }}
         run: .github/scripts/run-targets.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,6 @@ jobs:
       
         arch:
           - github/ubuntu/gnu/9.3.0
-          - github/ubuntu/nvhpc/21.9
           
         io_library_flag: ['']  # Switch between Serialbox and HDF5
         # FIXME: serialbox builds are currently disabled until a compatible serialbox version is available to Github actions
@@ -40,10 +39,13 @@ jobs:
 
         gpu_flag: ['', '--with-gpu']  # GPU-variants enabled
 
-        exclude:
-          # Do not build nvhpc without gpu variants
+        include:
+          # Add a single nvhpc build configuration
           - arch: github/ubuntu/nvhpc/21.9
-            gpu_flag: ''
+            io_library_flag: ''
+            mpi_flag: ''
+            prec_flag: ''
+            gpu_flag: '--with-gpu'
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Install MPI
-      - name: Install MPI
+      - name: Install MPI via Apt
         if: contains( matrix.mpi_flag, 'with-mpi' )
         run: sudo apt-get install libopenmpi-dev
 
@@ -63,14 +63,14 @@ jobs:
         run: .github/scripts/bootstrap-nvhpc.sh
 
       # Install HDF5
-      - name: Install HDF5
-        if: contains( matrix.arch, 'nvhpc' ) && ! contains( matrix.io_library_flag, 'with-serialbox' )
-        run: source ${{ matrix.arch }} && .github/scripts/install-hdf5.sh
-
-      - name: Install HDF5
+      - name: Install HDF5 via Apt
         if: contains( matrix.arch, 'gnu' ) && ! contains( matrix.io_library_flag, 'with-serialbox' )
         run: sudo apt-get install libhdf5-dev
       
+      - name: Install HDF5 from source
+        if: contains( matrix.arch, 'nvhpc' ) && ! contains( matrix.io_library_flag, 'with-serialbox' )
+        run: source arch/${{ matrix.arch }} && .github/scripts/install-hdf5.sh
+
       # Check-out dependencies as part of the bundle creation
       - name: Bundle create
         run: ./cloudsc-bundle create

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
       
         arch:
           - github/ubuntu/gnu/9.3.0
+          - github/ubuntu/nvhpc/21.9
           
         io_library_flag: ['']  # Switch between Serialbox and HDF5
         # FIXME: serialbox builds are currently disabled until a compatible serialbox version is available to Github actions
@@ -38,6 +39,11 @@ jobs:
         prec_flag: ['', '--single-precision']  # Switch single/double precision
 
         gpu_flag: ['', '--with-gpu']  # GPU-variants enabled
+
+        exclude:
+          # Do not build nvhpc without gpu variants
+          - arch: github/ubuntu/nvhpc/21.9
+            gpu_flag: ''
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -49,6 +55,7 @@ jobs:
         run: |
           [[ "${{ matrix.mpi_flag }}" == "--with-mpi" ]] && sudo apt install libopenmpi-dev || true
           [[ "${{ matrix.io_library_flag }}" != "--with-serialbox" ]] && sudo apt install libhdf5-dev || true
+          [[ "${{ matrix.arch }}" == *"nvhpc"* ]] && .github/scripts/bootstrap-nvhpc.sh || true
       
       # Check-out dependencies as part of the bundle creation
       - name: Bundle create

--- a/arch/github/ubuntu/nvhpc/21.9/env.sh
+++ b/arch/github/ubuntu/nvhpc/21.9/env.sh
@@ -24,6 +24,8 @@ export PATH=${MPI_HOME}/bin:${PATH}
 
 ### HDF5
 export HDF5_DIR=${GITHUB_WORKSPACE}/hdf5-install
+export LD_LIBRARY_PATH=${HDF5_DIR}/lib:${LD_LIBRARY_PATH}
+export PATH=${HDF5_DIR}/bin:${PATH}
 
 ### Compiler variables
 export CC=nvc

--- a/arch/github/ubuntu/nvhpc/21.9/env.sh
+++ b/arch/github/ubuntu/nvhpc/21.9/env.sh
@@ -1,0 +1,33 @@
+# (C) Copyright 1988- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+# Source me to get the correct configure/build/run environment
+
+### Variables
+export NVHPC_INSTALL_DIR=${GITHUB_WORKSPACE}/nvhpc-install
+export NVHPC_VERSION=21.9
+export NVHPC_DIR=${NVHPC_INSTALL_DIR}/Linux_x86_64/${NVHPC_VERSION}
+
+### Compilers
+export PATH=${NVHPC_DIR}/compilers/bin:${PATH}
+export NVHPC_LIBRARY_PATH=${NVHPC_DIR}/compilers/lib
+export LD_LIBRARY_PATH=${NVHPC_LIBRARY_PATH}
+
+### MPI
+export MPI_HOME=${NVHPC_DIR}/comm_libs/mpi
+export PATH=${MPI_HOME}/bin:${PATH}
+
+### HDF5
+export HDF5_DIR=${GITHUB_WORKSPACE}/hdf5-install
+
+### Compiler variables
+export CC=nvc
+export CXX=nvc++
+export FC=nvfortran
+
+export ECBUILD_TOOLCHAIN="./toolchain.cmake"

--- a/arch/github/ubuntu/nvhpc/21.9/env.sh
+++ b/arch/github/ubuntu/nvhpc/21.9/env.sh
@@ -28,8 +28,8 @@ export LD_LIBRARY_PATH=${HDF5_DIR}/lib:${LD_LIBRARY_PATH}
 export PATH=${HDF5_DIR}/bin:${PATH}
 
 ### Compiler variables
-export CC=nvc
-export CXX=nvc++
-export FC=nvfortran
+export CC=pgcc
+export CXX=pgc++
+export FC=pgf90
 
 export ECBUILD_TOOLCHAIN="./toolchain.cmake"

--- a/arch/github/ubuntu/nvhpc/21.9/toolchain.cmake
+++ b/arch/github/ubuntu/nvhpc/21.9/toolchain.cmake
@@ -1,0 +1,1 @@
+../../../../toolchains/github-ubuntu-nvhpc.cmake

--- a/arch/toolchains/github-ubuntu-nvhpc.cmake
+++ b/arch/toolchains/github-ubuntu-nvhpc.cmake
@@ -1,0 +1,49 @@
+# (C) Copyright 1988- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+####################################################################
+# COMPILER
+####################################################################
+
+set( ECBUILD_FIND_MPI ON )
+
+####################################################################
+# OpenMP FLAGS
+####################################################################
+
+set( OpenMP_C_FLAGS             "-mp -mp=bind,allcores,numa" )
+set( OpenMP_CXX_FLAGS           "-mp -mp=bind,allcores,numa" )
+set( OpenMP_Fortran_FLAGS       "-mp -mp=bind,allcores,numa" )
+
+####################################################################
+# OpenAcc FLAGS
+####################################################################
+
+set( OpenACC_Fortran_FLAGS "-acc -ta=tesla:lineinfo,deepcopy,fastmath" )
+# Enable this to get more detailed compiler output
+# set( OpenACC_Fortran_FLAGS "${OpenACC_Fortran_FLAGS} -Minfo" )
+
+####################################################################
+# COMMON FLAGS
+####################################################################
+
+set(ECBUILD_Fortran_FLAGS "-fpic")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -Mframe")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -Mbyteswapio")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -Mstack_arrays")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -Mrecursive")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -Ktrap=fp")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -Kieee")
+set(ECBUILD_Fortran_FLAGS "${ECBUILD_Fortran_FLAGS} -Mdaz")
+
+set( ECBUILD_Fortran_FLAGS_BIT "-O2 -gopt" )
+
+set( ECBUILD_C_FLAGS "-O2 -gopt -traceback" )
+
+set( ECBUILD_CXX_FLAGS "-O2 -gopt" )
+

--- a/arch/toolchains/github-ubuntu-nvhpc.cmake
+++ b/arch/toolchains/github-ubuntu-nvhpc.cmake
@@ -24,7 +24,7 @@ set( OpenMP_Fortran_FLAGS       "-mp -mp=bind,allcores,numa" )
 # OpenAcc FLAGS
 ####################################################################
 
-set( OpenACC_Fortran_FLAGS "-acc -ta=tesla:lineinfo,deepcopy,fastmath" )
+set( OpenACC_Fortran_FLAGS "-acc=gpu -gpu=lineinfo,fastmath" )
 # Enable this to get more detailed compiler output
 # set( OpenACC_Fortran_FLAGS "${OpenACC_Fortran_FLAGS} -Minfo" )
 


### PR DESCRIPTION
Small addition to our Github actions configuration that verifies builds with NVHPC using the bootstrap script from Atlas.

This can't actually validate results as we can't run the GPU variants but might highlight compile-time problems, in particular with OpenACC annotations, early on.

Takes a bit longer than the other jobs as it needs to download nvhpc and compile hdf5 from source (which takes ~3 and 10 mins, respectively).