### PR TITLE
Use type name instead of variable name for type-bound procedures

### DIFF
--- a/src/cloudsc_loki/cloudsc_loki.config
+++ b/src/cloudsc_loki/cloudsc_loki.config
@@ -7,8 +7,9 @@ strict = true  # Throw exceptions during dicovery
 # Ensure that we are never adding these to the tree, and thus
 # do not attempt to look up the source files for these.
 # TODO: Add type-bound procedure support and adjust scheduler to it
-disable = ['timer%start', 'timer%end', 'timer%thread_start', 'timer%thread_end',
-           'timer%thread_log', 'timer%thread_log', 'timer%print_performance']
+disable = ['performance_timer%start', 'performance_timer%end', 'performance_timer%thread_start',
+           'performance_timer%thread_end', 'performance_timer%thread_log',
+           'performance_timer%thread_log', 'performance_timer%print_performance']
 
 # Define entry point for call-tree transformation
 [[routine]]


### PR DESCRIPTION
An update for the Loki configuration in line with Loki PR #134.