### PR TITLE
Hotfix: Use 20.04 runner image and make sure GNU 9.4 is installed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     name: Test on ${{ matrix.arch }} ${{ matrix.io_library_flag }} ${{ matrix.mpi_flag }} ${{ matrix.prec_flag }} ${{ matrix.gpu_flag }} ${{ matrix.loki_flag }} ${{ matrix.claw_flag }}
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false  # false: try to complete all jobs
@@ -63,7 +63,7 @@ jobs:
       # Installs required packages
       - name: Package installation
         run: |
-          sudo apt-get install libc-dev-bin
+          sudo apt-get install libc-dev-bin gfortran-9 gcc-9 g++-9
 
       # Install MPI
       - name: Install MPI via Apt

--- a/arch/github/ubuntu/gnu/9.4.0/env.sh
+++ b/arch/github/ubuntu/gnu/9.4.0/env.sh
@@ -1,7 +1,7 @@
 # Source me to get the correct configure/build/run environment
 
-export CC=gcc
-export CXX=g++
+export CC=gcc-9
+export CXX=g++-9
 export FC=gfortran-9
 
 export ECBUILD_TOOLCHAIN="./toolchain.cmake"


### PR DESCRIPTION
Github is transitioning ubuntu-latest to 22.04 runner images and so we end up with different compiler versions randomly. This should make sure we are using GNU 9.4 every time.