### PR TITLE
Minor fixes to compile and run the dwarf on Mac M1

### DIFF
--- a/src/common/module/yoethf.F90
+++ b/src/common/module/yoethf.F90
@@ -72,9 +72,9 @@ REAL(KIND=JPRB) :: RKOOP2
 !$acc   r5alvcp, r5alscp, ralvdcp, ralsdcp, ralfdcp, rtwat, rtice, rticecu, &
 !$acc   rtwat_rtice_r, rtwat_rticecu_r, rkoop1, rkoop2)
 
-!$omp declare target(r2es, r3les, r3ies, r4les, r4ies, r5les, r5ies, &
-!$omp   r5alvcp, r5alscp, ralvdcp, ralsdcp, ralfdcp, rtwat, rtice, rticecu, &
-!$omp   rtwat_rtice_r, rtwat_rticecu_r, rkoop1, rkoop2)
+!$omp declare target(r2es, r3les, r3ies, r4les, r4ies, r5les, r5ies)
+!$omp declare target(  r5alvcp, r5alscp, ralvdcp, ralsdcp, ralfdcp, rtwat, rtice, rticecu)
+!$omp declare target(  rtwat_rtice_r, rtwat_rticecu_r, rkoop1, rkoop2)
 
 !       ----------------------------------------------------------------
 

--- a/src/prototype1/cloudsc/cloudsc_driver.F90
+++ b/src/prototype1/cloudsc/cloudsc_driver.F90
@@ -134,7 +134,7 @@ CALL GET_ENVIRONMENT_VARIABLE('CLOUDSC_WRITE_INPUT', write_input)
 CALL GET_ENVIRONMENT_VARIABLE('CLOUDSC_WRITE_REFERENCE', write_reference)
 
 open(iu,file='cloudsc.bin',status='old',&
-     & access='stream', form='unformatted')
+     & access='stream', form='unformatted', convert='BIG_ENDIAN')
 
 read(iu) KLON,KLEV,KFLDX
 write(0,*) 'KLON,KLEV,KFLDX,NCLV=',KLON,KLEV,KFLDX,NCLV


### PR DESCRIPTION
Fixes to compile and run the develop branch of CLOUDSC on Mac M1 with gfortran: 1) added missing omp declarations and 2) specifically requested endiannes conversion when opening Fortran tape by a "Prototype" dwarf version (unofficial functionality of Fortran compilers, trick as suggested by WD).