### PR TITLE
Enable gvmode and add nvidia/22.11 arch files

### DIFF
--- a/arch/ecmwf/hpc2020/nvhpc/22.11/env.sh
+++ b/arch/ecmwf/hpc2020/nvhpc/22.11/env.sh
@@ -1,0 +1,52 @@
+# (C) Copyright 1988- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+# Source me to get the correct configure/build/run environment
+
+# Store tracing and disable (module is *way* too verbose)
+{ tracing_=${-//[^x]/}; set +x; } 2>/dev/null
+
+module_load() {
+  echo "+ module load $1"
+  module load $1
+}
+module_unload() {
+  echo "+ module unload $1"
+  module unload $1
+}
+
+# Unload all modules to be certain
+module_unload nvidia
+module_unload intel-mpi
+module_unload openmpi
+module_unload hpcx-openmpi
+module_unload boost
+module_unload hdf5
+module_unload cmake
+module_unload python3
+module_unload java
+
+# Load modules
+module_load prgenv/nvidia
+module_load nvidia/22.11
+module_load hpcx-openmpi/2.10.0
+# module_load boost/1.71.0
+module_load hdf5/1.10.6
+module_load cmake/3.25.2
+module_load python3/3.10.10-01
+module_load java/11.0.6
+
+# Increase stack size to maximum
+ulimit -S -s unlimited
+
+set -x
+
+# Restore tracing to stored setting
+{ if [[ -n "$tracing_" ]]; then set -x; else set +x; fi } 2>/dev/null
+
+export ECBUILD_TOOLCHAIN="./toolchain.cmake"

--- a/arch/ecmwf/hpc2020/nvhpc/22.11/toolchain.cmake
+++ b/arch/ecmwf/hpc2020/nvhpc/22.11/toolchain.cmake
@@ -1,0 +1,1 @@
+../../../../toolchains/ecmwf-hpc2020-nvhpc.cmake

--- a/arch/toolchains/ecmwf-hpc2020-nvhpc.cmake
+++ b/arch/toolchains/ecmwf-hpc2020-nvhpc.cmake
@@ -31,9 +31,11 @@ set( OpenMP_C_LIB_NAMES     "acchost" CACHE STRING "")
 # OpenAcc FLAGS
 ####################################################################
 
+# Importantly, enable `gvmode` to remove the limit of 32 vector threads
+# per thread block
 # NB: We have to add `-mp` again to avoid undefined symbols during linking
 # (smells like an Nvidia bug)
-set( OpenACC_Fortran_FLAGS "-acc=gpu -mp=gpu -gpu=cc80,lineinfo,fastmath" CACHE STRING "" )
+set( OpenACC_Fortran_FLAGS "-acc=gpu -mp=gpu -gpu=cc80,lineinfo,fastmath,gvmode" CACHE STRING "" )
 # Enable this to get more detailed compiler output
 # set( OpenACC_Fortran_FLAGS "${OpenACC_Fortran_FLAGS} -Minfo" )
 

--- a/src/cloudsc_gpu/CMakeLists.txt
+++ b/src/cloudsc_gpu/CMakeLists.txt
@@ -180,10 +180,10 @@ endif()
 
 
 if( HAVE_CLOUDSC_GPU_SCC_CUF )
-    # Compile CUDA fortran files with -MCuda.
+    # Compile CUDA fortran files with -cuda.
     cloudsc_add_compile_options(
         SOURCES cloudsc_gpu_scc_cuf_mod.F90  cloudsc_driver_gpu_scc_cuf_mod.F90
-        FLAGS   "-Mcuda=maxregcount:128")
+        FLAGS   "-cuda -gpu=maxregcount:128")
 
     ecbuild_add_executable(
         TARGET dwarf-cloudsc-gpu-scc-cuf
@@ -208,10 +208,10 @@ endif()
 
 if ( HAVE_CLOUDSC_GPU_SCC_CUF_K_CACHING )
     # NEW CUF with k-caching!!!!
-    # Compile CUDA fortran files with -MCuda.
+    # Compile CUDA fortran files with -cuda.
     cloudsc_add_compile_options(
         SOURCES cloudsc_gpu_scc_cuf_k_caching_mod.F90  cloudsc_driver_gpu_scc_cuf_k_caching_mod.F90
-        FLAGS   "-Mcuda=maxregcount:128")
+        FLAGS   "-cuda -gpu=maxregcount:128")
 
     ecbuild_add_executable(
         TARGET dwarf-cloudsc-gpu-scc-cuf-k-caching

--- a/src/cloudsc_loki/CMakeLists.txt
+++ b/src/cloudsc_loki/CMakeLists.txt
@@ -571,13 +571,13 @@ if( HAVE_CUDA )
         OUTPUT
             loki-scc-cuf-parametrise/cuf_cloudsc_driver_loki_mod.cuf_parametrise.F90
             loki-scc-cuf-parametrise/cuf_cloudsc.cuf_parametrise.F90
-	DEPENDS cuf_cloudsc.F90 cuf_cloudsc_driver_loki_mod.F90 ${_OMNI_DEPENDENCIES}
+	    DEPENDS cuf_cloudsc.F90 cuf_cloudsc_driver_loki_mod.F90 ${_OMNI_DEPENDENCIES}
     )
 
     set_source_files_properties(
         loki-scc-cuf-parametrise/cuf_cloudsc_driver_loki_mod.cuf_parametrise.F90
         loki-scc-cuf-parametrise/cuf_cloudsc.cuf_parametrise.F90
-        PROPERTIES COMPILE_FLAGS "-Mcuda=maxregcount:128"
+        PROPERTIES COMPILE_FLAGS "-cuda -gpu=maxregcount:128"
     )
 
     ecbuild_add_executable( TARGET dwarf-cloudsc-loki-scc-cuf-parametrise
@@ -590,8 +590,7 @@ if( HAVE_CUDA )
         DEFINITIONS ${CLOUDSC_DEFINITIONS} CLOUDSC_GPU_SCC_CUF
     )
 
-    # target_compile_definitions(dwarf-cloudsc-loki-scc-cuf-parametrise PUBLIC USE_CUDA_DRIVER=1)
-    target_link_options(dwarf-cloudsc-loki-scc-cuf-parametrise PUBLIC "-Mcuda")
+    target_link_options(dwarf-cloudsc-loki-scc-cuf-parametrise PUBLIC "-cuda")
 
     ecbuild_add_test(
         TARGET dwarf-cloudsc-loki-scc-cuf-parametrise-serial
@@ -626,8 +625,8 @@ if( HAVE_CUDA )
 
     set_source_files_properties(
         loki-scc-cuf-hoist/cuf_cloudsc_driver_loki_mod.cuf_hoist.F90
-	loki-scc-cuf-hoist/cuf_cloudsc.cuf_hoist.F90
-	PROPERTIES COMPILE_FLAGS "-Mcuda=maxregcount:128"
+	    loki-scc-cuf-hoist/cuf_cloudsc.cuf_hoist.F90
+	    PROPERTIES COMPILE_FLAGS "-cuda -gpu=maxregcount:128"
     )
 
     ecbuild_add_executable( TARGET dwarf-cloudsc-loki-scc-cuf-hoist
@@ -640,8 +639,7 @@ if( HAVE_CUDA )
         DEFINITIONS ${CLOUDSC_DEFINITIONS} CLOUDSC_GPU_SCC_CUF
     )
 
-    # target_compile_definitions(dwarf-cloudsc-loki-scc-cuf-hoist PUBLIC USE_CUDA_DRIVER=1)
-    target_link_options(dwarf-cloudsc-loki-scc-cuf-hoist PUBLIC "-Mcuda")
+    target_link_options(dwarf-cloudsc-loki-scc-cuf-hoist PUBLIC "-cuda")
 
     ecbuild_add_test(
         TARGET dwarf-cloudsc-loki-scc-cuf-hoist-serial

--- a/src/cloudsc_loki/CMakeLists.txt
+++ b/src/cloudsc_loki/CMakeLists.txt
@@ -440,7 +440,7 @@ if( HAVE_CLOUDSC_LOKI )
         ARGS 1 1280 128
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../..
         OMP 1
-        ENVIRONMENT "NVCOMPILER_ACC_CUDA_HEAPSIZE=64M"
+        ENVIRONMENT "NVCOMPILER_ACC_CUDA_HEAPSIZE=128M"
     )
 
     ######################################################

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -44,7 +44,7 @@ list(APPEND CLOUDSC_CUDA_SOURCES
 
 if( HAVE_CUDA )
     # ========================================================================
-    # Compile CUDA fortran files with -MCuda.
+    # Compile CUDA fortran files with -cuda.
     #
     # This is necessary since CMake's CUDA languages does not natively
     # understand CUDA-Fortran (.cuf) yet. So we simply emulate .cuf with
@@ -52,7 +52,7 @@ if( HAVE_CUDA )
     # ========================================================================
     cloudsc_add_compile_options(
         SOURCES ${CLOUDSC_CUDA_SOURCES}
-        FLAGS "-Mcuda=maxregcount:128"
+        FLAGS "-cuda -gpu=maxregcount:128"
     )
 
     # Add CUDA-specific flags to the library if enabled
@@ -98,5 +98,5 @@ ecbuild_add_library( TARGET cloudsc-common-lib
 )
 
 if( HAVE_CUDA )
-    target_link_options( cloudsc-common-lib INTERFACE "-Mcuda" )
+    target_link_options( cloudsc-common-lib PUBLIC "-cuda" )
 endif()

--- a/src/common/module/cloudsc_field_state_mod.F90
+++ b/src/common/module/cloudsc_field_state_mod.F90
@@ -27,8 +27,8 @@ MODULE CLOUDSC_FIELD_STATE_MOD
   TYPE CLOUDSC_FIELD_STATE
     INTEGER(KIND=JPIM)                   :: NPROMA, KLEV    ! Grid points and vertical levels per block
     INTEGER(KIND=JPIM)                   :: NGPTOT, NBLOCKS ! Total number of grid points and blocks
-    INTEGER(KIND=JPIM)                   :: KFLDX 
-    LOGICAL(KIND=JPLM)                   :: LDSLPHY 
+    INTEGER(KIND=JPIM)                   :: KFLDX
+    LOGICAL(KIND=JPLM)                   :: LDSLPHY
     LOGICAL(KIND=JPLM)                   :: LDMAINCALL      ! T if main call to cloudsc
     REAL(KIND=JPRB)                      :: PTSPHY          ! Physics timestep
 
@@ -273,7 +273,7 @@ CONTAINS
     DO B=1, NBLOCKS
        FIELD(:,B) = 0.0_JPRB
     END DO
-!$omp end parallel do 
+!$omp end parallel do
   END SUBROUTINE FIELD_INIT_R1
 
   SUBROUTINE FIELD_INIT_R2(FIELD, NPROMA, NLEV, NBLOCKS)
@@ -287,7 +287,7 @@ CONTAINS
     DO B=1, NBLOCKS
        FIELD(:,:,B) = 0.0_JPRB
     END DO
-!$omp end parallel do 
+!$omp end parallel do
   END SUBROUTINE FIELD_INIT_R2
 
   SUBROUTINE FIELD_INIT_R3(FIELD, NPROMA, NLEV, NDIM, NBLOCKS)
@@ -301,7 +301,7 @@ CONTAINS
     DO B=1, NBLOCKS
        FIELD(:,:,:,B) = 0.0_JPRB
     END DO
-!$omp end parallel do 
+!$omp end parallel do
   END SUBROUTINE FIELD_INIT_R3
 
   SUBROUTINE FIELD_INIT_STATE(STATE, BUFFER, NPROMA, NLEV, NDIM, NBLOCKS)
@@ -325,7 +325,7 @@ CONTAINS
        STATE(B)%Q => BUFFER(:,:,3,B)
        STATE(B)%CLD => BUFFER(:,:,4:NFIELDS,B)
     END DO
-!$omp end parallel do 
+!$omp end parallel do
   END SUBROUTINE FIELD_INIT_STATE
 
   SUBROUTINE CLOUDSC_FIELD_STATE_LOAD(SELF, NPROMA, NGPTOT, NGPTOTG, USE_PACKED)

--- a/src/common/module/yomphyder.F90
+++ b/src/common/module/yomphyder.F90
@@ -63,7 +63,7 @@ type aux_type
   REAL(KIND=JPRB), dimension(:), pointer   :: PGAW         ! GAUSSIAN WEIGHTS - Reduced Grid - ~ grid box area
   REAL(KIND=JPRB), dimension(:), pointer   :: PCLON, PSLON ! cosine, sine of longitude
   REAL(KIND=JPRB), dimension(:), pointer   :: PMU0, PMU0M  ! local cosine of instantaneous (mean) solar zenith angle
-  REAL(KIND=JPRB), dimension(:), pointer   :: PGEMU        ! sine of latitude 
+  REAL(KIND=JPRB), dimension(:), pointer   :: PGEMU        ! sine of latitude
   REAL(KIND=JPRB), dimension(:), pointer   :: POROG        ! orography
   REAL(KIND=JPRB), dimension(:), pointer   :: PGNORDL,PGNORDM ! Longitudial/latitudial derivatives of orography
   REAL(KIND=JPRB), dimension(:), pointer   :: PGSQM2
@@ -73,7 +73,7 @@ type surf_and_more_type
   REAL(KIND=JPRB), dimension(:,:), pointer :: PSP_SG, PSP_SL, PSP_RR, PSP_X2, PSD_WS, PSD_VF, &
     &                                         PSD_VN, PSD_V2, PSD_VD, PSD_X2, PSD_WW
   REAL(KIND=JPRB), dimension(:,:,:), pointer :: PSP_OM, PSP_SB, PSP_EP, PSD_V3, PSD_XA
-  REAL(KIND=JPRB), dimension(:,:,:), pointer :: PEXTRD 
+  REAL(KIND=JPRB), dimension(:,:,:), pointer :: PEXTRD
   REAL(KIND=JPRB), dimension(:,:), pointer :: PCOVPTOT  !Precip fraction
   REAL(KIND=JPRB), dimension(:), pointer :: PQCFL
   ! T star tiles
@@ -82,7 +82,7 @@ type surf_and_more_type
   REAL(KIND=JPRB), dimension(:,:), pointer :: PAHFSTI  ! (INSTANTANEOUS) SURFACE SENSIBLE HEAT FLUX FOR EACH TILE
   REAL(KIND=JPRB), dimension(:,:), pointer :: PEVAPTI  ! (INSTANTANEOUS) EVAPORATION FOR EACH TILE
   REAL(KIND=JPRB), dimension(:,:), pointer :: PTSKTI   ! SKIN TEMPERATURE FOR EACH TILE
-  ! other 
+  ! other
   REAL(KIND=JPRB), dimension(:), pointer ::  PEMIS      ! MODEL SURFACE LONGWAVE EMISSIVITY.
   ! GPP/REC flux adjustment coefficients
   REAL(KIND=JPRB), dimension(:), pointer :: PCGPP, PCREC ! to store bias correction coefficients
@@ -109,7 +109,7 @@ type surf_and_more_type
   REAL(KIND=JPRB), dimension(:),  pointer  :: PTLMNWE1       ! tendency of lake totat layer temperature
   REAL(KIND=JPRB), dimension(:),  pointer  :: PTLWMLE1       ! tendency of lake mixed layer temperature
   REAL(KIND=JPRB), dimension(:),  pointer  :: PTLBOTE1       ! tendency of lake bottom layer temperature
-  REAL(KIND=JPRB), dimension(:),  pointer  :: PTLSFE1        ! tendency of lake shape factor - 
+  REAL(KIND=JPRB), dimension(:),  pointer  :: PTLSFE1        ! tendency of lake shape factor -
   REAL(KIND=JPRB), dimension(:),  pointer  :: PHLICEE1       ! tendency of lake ice depth m
   REAL(KIND=JPRB), dimension(:),  pointer  :: PHLMLE1        ! tendency of lake mixed layer depth m/s
 end type surf_and_more_type
@@ -117,11 +117,11 @@ end type surf_and_more_type
 type perturb_in_type
   REAL(KIND=JPRB), dimension(:), pointer ::  PSTOPHU,PSTOPHV,PSTOPHT,PSTOPHQ ! random number for defining stochastic
                                                                 !  perturbation for U, V, T, and Q diabatic tendency.
-  REAL(KIND=JPRB), dimension(:), pointer ::  PSTOPHCA  ! CA pattern 
+  REAL(KIND=JPRB), dimension(:), pointer ::  PSTOPHCA  ! CA pattern
   REAL(KIND=JPRB), dimension(:,:), pointer :: PGP2DSDT
   REAL(KIND=JPRB), dimension(:,:), pointer :: PVORT, PVORTGRADX, PVORTGRADY ! vorticity and its horizontal gradients
   REAL(KIND=JPRB), dimension(:,:), pointer :: PTOTDISS_SMOOTH ! smoothed total dissipation rate
-  REAL(KIND=JPRB), dimension(:,:), pointer :: PFORCEU, PFORCEV, PFORCET, PFORCEQ ! nonlinear stochastic forcing terms 
+  REAL(KIND=JPRB), dimension(:,:), pointer :: PFORCEU, PFORCEV, PFORCET, PFORCEQ ! nonlinear stochastic forcing terms
 end type perturb_in_type
 
 
@@ -144,7 +144,7 @@ type aux_rad_type
   REAL(KIND=JPRB), dimension(:,:), pointer :: PTRSC    ! (KLON,0:KLEV)  Clear-sky shortwave transmissivity
   REAL(KIND=JPRB), dimension(:,:,:), pointer :: PTAUAER ! (KLON,KLEV,6)  OPTICAL THICKNESS FOR 6 AEROSOL TYPES
   REAL(KIND=JPRB), dimension(:), pointer :: PSRLWD     ! (KLON)  Surface downward longwave flux
-  REAL(KIND=JPRB), dimension(:), pointer :: PSRLWDC    ! (KLON)  SURFACE DOWNWARD CLEAR-SKY LONGWAVE 
+  REAL(KIND=JPRB), dimension(:), pointer :: PSRLWDC    ! (KLON)  SURFACE DOWNWARD CLEAR-SKY LONGWAVE
   REAL(KIND=JPRB), dimension(:), pointer :: PSRSWD     ! (KLON)  SURFACE SHORTWAVE DOWNWARDS
   REAL(KIND=JPRB), dimension(:), pointer :: PSRSWDC    ! (KLON)  SURFACE DOWNWARD CLEAR-SKY SHORTWAVE
   REAL(KIND=JPRB), dimension(:), pointer :: PSRSWDCS   ! (KLON)  SURFACE NET SHORTWAVE CLEAR-SKY
@@ -186,7 +186,7 @@ type aux_diag_type
   !    3D DIAGNOSTICS FOR ERA40
   REAL(KIND=JPRB), dimension(:,:), pointer :: PMFUDE_RATE   ! UD detrainmnet rate (KG/(M3*S))
   REAL(KIND=JPRB), dimension(:,:), pointer :: PMFDDE_RATE   ! DD detrainmnet rate (KG/(M3*S))
-  REAL(KIND=JPRB), dimension(:,:), pointer :: PKH_VDF       ! turbulent diffusion coefficient for heat 
+  REAL(KIND=JPRB), dimension(:,:), pointer :: PKH_VDF       ! turbulent diffusion coefficient for heat
   !    array for precipitation fraction
   REAL(KIND=JPRB), dimension(:,:), pointer :: PCOVPTOT     !  PRECIPITATION FRACTION IN EACH LAYER
   ! Convection and PBL types
@@ -305,13 +305,13 @@ type surf_and_more_local_type
    REAL(KIND=JPRB), dimension(:,:),  pointer  :: ZFRSOTI
    REAL(KIND=JPRB), dimension(:,:),  pointer  :: ZAHFTRTI
    REAL(KIND=JPRB), dimension(:,:),  pointer  :: ZALBD,ZALBP ! KLON,NTSW
-   !  CTESSEL: Carbon model 
+   !  CTESSEL: Carbon model
    REAL(KIND=JPRB), dimension(:,:),  pointer  :: ZANDAYVT, ZANFMVT
    REAL(KIND=JPRB), dimension(:,:,:),pointer  :: ZDHVEGS
 end type surf_and_more_local_type
 
 type aux_diag_local_type
-  INTEGER(KIND=JPIM), pointer :: IEXT3D   ! position in extra field for diagnostics 
+  INTEGER(KIND=JPIM), pointer :: IEXT3D   ! position in extra field for diagnostics
   REAL(KIND=JPRB), dimension(:), pointer :: ZWND     ! horizontal wind in the lowest model level
   REAL(KIND=JPRB), dimension(:), pointer :: ZCCNL, ZCCNO
   INTEGER(KIND=JPIM), dimension(:), pointer :: ITOPC, IBASC, IBOTSC
@@ -327,8 +327,8 @@ type aux_diag_local_type
   REAL(KIND=JPRB), dimension(:,:), pointer :: ZSOTEV    ! Explicit part of V-tendency from subgrid orography scheme
   REAL(KIND=JPRB), dimension(:,:), pointer :: ZSOBETA   ! Implicit part of subgrid orography
   ! aerosols in microphysics
-  REAL(KIND=JPRB), dimension(:,:), pointer :: ZLCRIT_AER ! critical liquid mmr for rain autoconversion process 
-  REAL(KIND=JPRB), dimension(:,:), pointer :: ZICRIT_AER ! critical liquid mmr for snow autoconversion process 
+  REAL(KIND=JPRB), dimension(:,:), pointer :: ZLCRIT_AER ! critical liquid mmr for rain autoconversion process
+  REAL(KIND=JPRB), dimension(:,:), pointer :: ZICRIT_AER ! critical liquid mmr for snow autoconversion process
   REAL(KIND=JPRB), dimension(:,:), pointer :: ZRE_LIQ    ! effective radius liquid
   REAL(KIND=JPRB), dimension(:,:), pointer :: ZRE_ICE    ! effective radius ice
   REAL(KIND=JPRB), dimension(:,:), pointer :: ZCCN       ! CCN (prognostic, diagnostic)
@@ -352,4 +352,3 @@ type keys_local_type
 end type keys_local_type
 
 end module yomphyder
-


### PR DESCRIPTION
This adds the gvmode (gang-vector-mode) flag for NVHPC on HPC2020, and adds updated arch files for nvidia/22.11