### PR TITLE
Bundle integration for Atlas

### DIFF
--- a/.github/scripts/verify-targets.sh
+++ b/.github/scripts/verify-targets.sh
@@ -17,7 +17,7 @@ fi
 
 if [[ "$gpu_flag" == "--with-gpu" ]]
 then
-  targets+=(dwarf-cloudsc-gpu-scc dwarf-cloudsc-gpu-scc-hoist dwarf-cloudsc-gpu-scc-k-caching) 
+  targets+=(dwarf-cloudsc-gpu-scc dwarf-cloudsc-gpu-scc-hoist dwarf-cloudsc-gpu-scc-k-caching)
   targets+=(dwarf-cloudsc-gpu-omp-scc-hoist)
   if [[ "$claw_flag" == "--with-claw" ]]
   then
@@ -50,6 +50,11 @@ then
   then
     targets+=(dwarf-cloudsc-loki-scc-cuf-hoist dwarf-cloudsc-loki-scc-cuf-parametrise)
   fi
+fi
+
+if [[ "$atlas_flag" == "--with-atlas" ]]
+then
+  targets+=(dwarf-cloudsc-fortran-atlas)
 fi
 
 if [[ "$pyiface_flag" == "--cloudsc-fortran-pyiface=ON" ]]

--- a/.github/scripts/verify-targets.sh
+++ b/.github/scripts/verify-targets.sh
@@ -55,6 +55,9 @@ fi
 if [[ "$atlas_flag" == "--with-atlas" ]]
 then
   targets+=(dwarf-cloudsc-fortran-atlas)
+  # Atlas builds a number of binaries that end up in bin, too:
+  targets+=(atlas atlas-atest-mgrids atlas-gaussian-latitudes atlas-grids)
+  targets+=(atlas-io-list atlas-meshgen fckit)
 fi
 
 if [[ "$pyiface_flag" == "--cloudsc-fortran-pyiface=ON" ]]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,8 @@ jobs:
 
         loki_flag: ['', '--with-loki']  # Loki source-to-source translation enabled
 
+        atlas_flag: ['--with-atlas']  # Variant using Atlas-managed fields
+
         claw_flag: ['']  # Flag to enable CLAW-generated variants
 
         pyiface_flag: ['']  # Flag to enable Python-interface variant
@@ -57,6 +59,7 @@ jobs:
             gpu_flag: '--with-gpu'
             cuda_flag: '--with-cuda'
             loki_flag: '--with-loki'
+            atlas_flag: '--with-atlas'
             pyiface_flag: ''
             python_f2py_flag: ''
           - arch: github/ubuntu/nvhpc/21.9
@@ -66,6 +69,7 @@ jobs:
             gpu_flag: '--with-gpu'
             cuda_flag: '--with-cuda'
             loki_flag: '--with-loki'
+            atlas_flag: '--with-atlas'
             pyiface_flag: ''
             python_f2py_flag: ''
           # Add pyiface build configuration for HDF5 only
@@ -76,6 +80,7 @@ jobs:
             gpu_flag: ''
             cuda_flag: ''
             loki_flag: ''
+            atlas_flag: ''
             pyiface_flag: '--cloudsc-fortran-pyiface=ON'
             python_f2py_flag: '--cloudsc-python-f2py=ON'
 
@@ -124,7 +129,7 @@ jobs:
           --arch=arch/${{ matrix.arch }} ${{ matrix.prec_flag }} \
           ${{ matrix.mpi_flag }} ${{ matrix.io_library_flag }} ${{ matrix.gpu_flag }} \
           ${{ matrix.claw_flag}} ${{ matrix.loki_flag }} ${{ matrix.cuda_flag }} \
-          ${{ matrix.pyiface_flag }} ${{ matrix.python_f2py_flag }}
+          ${{ matrix.atlas_flag }} ${{ matrix.pyiface_flag }} ${{ matrix.python_f2py_flag }}
 
       # Verify targets exist
       - name: Verify targets
@@ -134,6 +139,7 @@ jobs:
           gpu_flag: ${{ matrix.gpu_flag }}
           cuda_flag: ${{ matrix.cuda_flag }}
           loki_flag: ${{ matrix.loki_flag }}
+          atlas_flag: ${{ matrix.atlas_flag }}
           claw_flag: ${{ matrix.claw_flag }}
           pyiface_flag: ${{ matrix.pyiface_flag }}
           python_f2py_flag: ${{ matrix.python_f2py_flag }}

--- a/bundle.yml
+++ b/bundle.yml
@@ -5,11 +5,15 @@ name    : cloudsc-bundle
 version : 1.0.0-develop
 cmake : >
         CMAKE_LINK_DEPENDS_NO_SHARED=ON
+        BUILD_field_api=OFF
+        BUILD_eckit=OFF
+        BUILD_fckit=OFF
+        BUILD_atlas=OFF
 
 projects :
 
     - ecbuild :
-        git     : https://github.com/ecmwf/ecbuild 
+        git     : https://github.com/ecmwf/ecbuild
         version : 3.7.0
         bundle  : false
 
@@ -36,13 +40,37 @@ projects :
             LOKI_ENABLE_TESTS=OFF
             LOKI_ENABLE_NO_INSTALL=ON
 
+    - eckit :
+        git     : https://github.com/ecmwf/eckit
+        version : 1.24.3
+        optional: true
+        require : ecbuild
+        cmake   : >
+            ECKIT_ENABLE_TESTS=OFF
+            ECKIT_ENABLE_BUILD_TOOLS=OFF
+
+    - fckit :
+        git     : https://github.com/ecmwf/fckit
+        version : 0.9.0
+        optional: true
+        require : ecbuild eckit
+        cmake   : >
+            FCKIT_ENABLE_TESTS=OFF
+
+    - atlas :
+        git     : https://github.com/ecmwf/atlas
+        version : master
+        optional: true
+        require : ecbuild eckit fckit
+        cmake   : >
+            ATLAS_ENABLE_TESTS=OFF
+
     - field_api :
         git     : ${BITBUCKET}/rdx/field_api
         version : master
         optional: true
         require : ecbuild
         cmake   : >
-            BUILD_field_api=OFF
             ENABLE_FIELD_API_TESTS=OFF
             ENABLE_FIELD_API_FIAT_BUILD=OFF
             FIELD_API_UTIL_MODULE_PATH=${CMAKE_SOURCE_DIR}/cloudsc-dwarf/src/common/module
@@ -110,6 +138,21 @@ options :
         help  : Enable Python variants of CLOUDSC
         cmake : >
             CLOUDSC_PYTHON_F2PY=ON
+
+    - with-atlas :
+        help  : Build Atlas and its dependencies (eckit, fckit) and enable Atlas-based variants of CLOUDSC
+        cmake : >
+            BUILD_eckit=ON
+            BUILD_fckit=ON
+            BUILD_atlas=ON
+
+    - with-dependency-tests :
+        help  : Build and enable tests for CLOUDSC dependencies that are build as part of the bundle (eckit, fckit, Atlas, Loki)
+        cmake : >
+            LOKI_ENABLE_TESTS=ON
+            ECKIT_ENABLE_TESTS=ON
+            FCKIT_ENABLE_TESTS=ON
+            ATLAS_ENABLE_TESTS=ON
 
     - cloudsc-prototype1 :
         help  : Build the original operational Fortran prototype [ON|OFF]

--- a/src/cloudsc_fortran_atlas/CMakeLists.txt
+++ b/src/cloudsc_fortran_atlas/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 
     ecbuild_add_test(
         TARGET dwarf-cloudsc-fortran-atlas-serial
-        COMMAND bin/dwarf-cloudsc-atlas-fortran
+        COMMAND bin/dwarf-cloudsc-fortran-atlas
         ARGS 1 100 16
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../..
         OMP 1

--- a/src/cloudsc_fortran_atlas/CMakeLists.txt
+++ b/src/cloudsc_fortran_atlas/CMakeLists.txt
@@ -27,7 +27,6 @@ if( HAVE_CLOUDSC_FORTRAN_ATLAS )
             atlas_f
         DEFINITIONS ${CLOUDSC_DEFINITIONS}
     )
-endif()
 
     # Create symlink for the input data
     if( HAVE_SERIALBOX )
@@ -75,3 +74,5 @@ endif()
         OMP 4
         CONDITION HAVE_OMP AND HAVE_MPI
     )
+
+endif()


### PR DESCRIPTION
As mentioned in the review of #54, this adds Atlas and its dependencies as optional projects to the bundle.
By default, they are not being built, which should allow to pick up an existing Atlas installation as usual. `--with-atlas` will enable building `eckit`, `fckit` and `atlas`. By default, tests are disabled for these dependencies but can be enabled using `--with-dependency-tests`.

I have also enabled Github actions integration for the new variant.