### PR TITLE
HDF5 support for CUDA/HIP/SYCL variants

### DIFF
--- a/.github/scripts/verify-targets.sh
+++ b/.github/scripts/verify-targets.sh
@@ -21,10 +21,7 @@ then
   if [[ "$build_flags" == *"--with-cuda"* ]]
   then
     targets+=(dwarf-cloudsc-gpu-scc-cuf dwarf-cloudsc-gpu-scc-cuf-k-caching)
-    if [[ "$io_library_flag" == "--with-serialbox" ]]
-    then
-        targets+=(dwarf-cloudsc-c-cuda dwarf-cloudsc-c-cuda-hoist dwarf-cloudsc-c-cuda-k-caching)
-    fi
+    targets+=(dwarf-cloudsc-c-cuda dwarf-cloudsc-c-cuda-hoist dwarf-cloudsc-c-cuda-k-caching)
   fi
 fi
 

--- a/src/cloudsc_cuda/CMakeLists.txt
+++ b/src/cloudsc_cuda/CMakeLists.txt
@@ -9,7 +9,7 @@
 # Define this dwarf variant as an ECBuild feature
 ecbuild_add_option( FEATURE CLOUDSC_C_CUDA
     DESCRIPTION "Build the CUDA version of CLOUDSC C using Serialbox" DEFAULT ON
-    CONDITION Serialbox_FOUND AND HAVE_CUDA
+    CONDITION (Serialbox_FOUND OR HDF5_FOUND) AND HAVE_CUDA
 )
 
 if( HAVE_CLOUDSC_C_CUDA )
@@ -36,9 +36,12 @@ if( HAVE_CLOUDSC_C_CUDA )
         PUBLIC_INCLUDES
             $<INSTALL_INTERFACE:include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cloudsc>
-        PUBLIC_LIBS
-            Serialbox::Serialbox_C
-            $<${HAVE_OMP}:OpenMP::OpenMP_C>
+	PUBLIC_LIBS
+	    $<${HAVE_HDF5}:hdf5::hdf5>
+	    $<${HAVE_SERIALBOX}:Serialbox::Serialbox_C>
+	    $<${HAVE_OMP}:OpenMP::OpenMP_C>
+	DEFINITIONS
+	    ${CLOUDSC_DEFINITIONS}
     )
 
     target_include_directories(
@@ -91,9 +94,12 @@ if( HAVE_CLOUDSC_C_CUDA )
         PUBLIC_INCLUDES
             $<INSTALL_INTERFACE:include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cloudsc>
-        PUBLIC_LIBS
-            Serialbox::Serialbox_C
-            $<${HAVE_OMP}:OpenMP::OpenMP_C>
+	PUBLIC_LIBS
+	    $<${HAVE_HDF5}:hdf5::hdf5>
+	    $<${HAVE_SERIALBOX}:Serialbox::Serialbox_C>
+	    $<${HAVE_OMP}:OpenMP::OpenMP_C>
+	DEFINITIONS
+	    ${CLOUDSC_DEFINITIONS}
     )
 
     target_include_directories(
@@ -146,9 +152,12 @@ if( HAVE_CLOUDSC_C_CUDA )
         PUBLIC_INCLUDES
             $<INSTALL_INTERFACE:include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cloudsc>
-        PUBLIC_LIBS
-            Serialbox::Serialbox_C
-            $<${HAVE_OMP}:OpenMP::OpenMP_C>
+	PUBLIC_LIBS
+	    $<${HAVE_HDF5}:hdf5::hdf5>
+	    $<${HAVE_SERIALBOX}:Serialbox::Serialbox_C>
+	    $<${HAVE_OMP}:OpenMP::OpenMP_C>
+	DEFINITIONS
+	    ${CLOUDSC_DEFINITIONS}
     )
 
     target_include_directories(
@@ -181,9 +190,19 @@ if( HAVE_CLOUDSC_C_CUDA )
     )
     ###
 
-    # Create symlink for the input data
-    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../data ${CMAKE_CURRENT_BINARY_DIR}/../../../data )
+
+ # Create symlink for the input data
+ if( HAVE_SERIALBOX )
+   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+       ${CMAKE_CURRENT_SOURCE_DIR}/../../data ${CMAKE_CURRENT_BINARY_DIR}/../../../data )
+ endif()
+
+ if( HAVE_HDF5 )
+   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+       ${CMAKE_CURRENT_SOURCE_DIR}/../../config-files/input.h5 ${CMAKE_CURRENT_BINARY_DIR}/../../../input.h5 )
+   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+       ${CMAKE_CURRENT_SOURCE_DIR}/../../config-files/reference.h5 ${CMAKE_CURRENT_BINARY_DIR}/../../../reference.h5 )
+ endif()
 
 else()
     ecbuild_info( "Serialbox and/or CUDA not found, disabling CUDA prototype(s)" )

--- a/src/cloudsc_cuda/cloudsc/cloudsc_validate.cu
+++ b/src/cloudsc_cuda/cloudsc/cloudsc_validate.cu
@@ -50,8 +50,6 @@ void validate_1d(const char *name, double * v_ref, double * v_field, int nlon, i
   /* Computes and prints errors in the "L2 norm sense" */
   int b, bsize, jk;
   double zminval, zmaxval, zdiff, zmaxerr, zerrsum, zsum, zrelerr, zavgpgp;
-  double (*field)[nlon] = (double (*)[nlon]) v_field;
-  double (*reference)[nlon] = (double (*)[nlon]) v_ref;
 
   zminval = +DBL_MAX;
   zmaxval = -DBL_MAX;
@@ -84,8 +82,6 @@ void validate_2d(const char *name, double *v_ref, double *v_field, int nlon, int
   /* Computes and prints errors in the "L2 norm sense" */
   int b, bsize, jl, jk;
   double zminval, zmaxval, zdiff, zmaxerr, zerrsum, zsum, zrelerr, zavgpgp;
-  double (*field)[nlev][nlon] = (double (*)[nlev][nlon]) v_field;
-  double (*reference)[nlev][nlon] = (double (*)[nlev][nlon]) v_ref;
 
   zminval = +DBL_MAX;
   zmaxval = -DBL_MAX;
@@ -121,8 +117,6 @@ void validate_3d(const char *name, double *v_ref, double *v_field, int nlon,
   /* Computes and prints errors in the "L2 norm sense" */
   int b, bsize, jl, jk, jm;
   double zminval, zmaxval, zdiff, zmaxerr, zerrsum, zsum, zrelerr, zavgpgp;
-  double (*field)[nclv][nlev][nlon] = (double (*)[nclv][nlev][nlon]) v_field;
-  double (*reference)[nclv][nlev][nlon] = (double (*)[nclv][nlev][nlon]) v_ref;
 
   zminval = +DBL_MAX;
   zmaxval = -DBL_MAX;

--- a/src/cloudsc_cuda/cloudsc/cloudsc_validate.cu
+++ b/src/cloudsc_cuda/cloudsc/cloudsc_validate.cu
@@ -64,14 +64,14 @@ void validate_1d(const char *name, double * v_ref, double * v_field, int nlon, i
   for (b = 0; b < nblocks; b++) {
     bsize = min(nlon, ngptot - b*nlon);  // field block size
     for (jk = 0; jk < bsize; jk++) {
-      zminval = fmin(zminval, field[b][jk]);
-      zmaxval = fmax(zmaxval, field[b][jk]);
+      zminval = fmin(zminval, v_field[b*nlon+jk]);
+      zmaxval = fmax(zmaxval, v_field[b*nlon+jk]);
 
       // Difference against reference result in one-norm sense
-      zdiff = fabs(field[b][jk] - reference[b][jk]);
+      zdiff = fabs(v_field[b*nlon+jk] - v_ref[b*nlon+jk]);
       zmaxerr = fmax(zmaxerr, zdiff);
       zerrsum = zerrsum + zdiff;
-      zsum = zsum + abs(reference[b][jk]);
+      zsum = zsum + abs(v_ref[b*nlon+jk]);
     }
   }
   zavgpgp = zerrsum / (double) ngptot;
@@ -99,13 +99,14 @@ void validate_2d(const char *name, double *v_ref, double *v_field, int nlon, int
     bsize = min(nlon, ngptot - b*nlon);  // field block size
     for (jl = 0; jl < nlev; jl++) {
       for (jk = 0; jk < bsize; jk++) {
-	zminval = fmin(zminval, field[b][jl][jk]);
-	zmaxval = fmax(zmaxval, field[b][jl][jk]);
+	zminval = fmin(zminval, v_field[b*nlev*nlon+jl*nlon+jk]);
+	zmaxval = fmax(zmaxval, v_field[b*nlev*nlon+jl*nlon+jk]);
+
 	// Difference against reference result in one-norm sense
-	zdiff = fabs(field[b][jl][jk] - reference[b][jl][jk]);
+	zdiff = fabs(v_field[b*nlev*nlon+jl*nlon+jk] - v_ref[b*nlev*nlon+jl*nlon+jk]);
 	zmaxerr = fmax(zmaxerr, zdiff);
 	zerrsum = zerrsum + zdiff;
-	zsum = zsum + abs(reference[b][jl][jk]);
+	zsum = zsum + abs(v_ref[b*nlev*nlon+jl*nlon+jk]);
       }
     }
   }
@@ -136,18 +137,18 @@ void validate_3d(const char *name, double *v_ref, double *v_field, int nlon,
     for (jm = 0; jm < nclv; jm++) {
       for (jl = 0; jl < nlev; jl++) {
 	for (jk = 0; jk < bsize; jk++) {
-	  zminval = fmin(zminval, field[b][jm][jl][jk]);
-	  zmaxval = fmax(zmaxval, field[b][jm][jl][jk]);
+	  zminval = fmin(zminval, v_field[b*nclv*nlev*nlon+jm*nlev*nlon+jl*nlon+jk]);
+	  zmaxval = fmax(zmaxval, v_field[b*nclv*nlev*nlon+jm*nlev*nlon+jl*nlon+jk]);
 
 	  // Difference against reference result in one-norm sense
-	  zdiff = fabs(field[b][jm][jl][jk] - reference[b][jm][jl][jk]);
+	  zdiff = fabs(v_field[b*nclv*nlev*nlon+jm*nlev*nlon+jl*nlon+jk] - v_ref[b*nclv*nlev*nlon+jm*nlev*nlon+jl*nlon+jk]);
 	  zmaxerr = fmax(zmaxerr, zdiff);
 	  zerrsum = zerrsum + zdiff;
-	  zsum = zsum + abs(reference[b][jm][jl][jk]);
+	  zsum = zsum + abs(v_ref[b*nclv*nlev*nlon+jm*nlev*nlon+jl*nlon+jk]);
 	}
       }
     }
-  }
+  }  
   zavgpgp = zerrsum / (double) ngptot;
   print_error(name, zminval, zmaxval, zmaxerr, zerrsum, zsum, zavgpgp, 2);
 }

--- a/src/cloudsc_cuda/cloudsc/load_state.cu
+++ b/src/cloudsc_cuda/cloudsc/load_state.cu
@@ -68,119 +68,66 @@ void query_state(int *klon, int *klev)
 
 void expand_1d(double *buffer, double *field_in, int nlon, int nproma, int ngptot, int nblocks)
 {
-  int b, l, i, buf_start_idx, buf_idx;
-  double (*field)[nproma] = (double (*)[nproma]) field_in;
+  int b, i, buf_start_idx, buf_idx;
 
-#pragma omp parallel for default(shared) private(b, l, i, buf_start_idx, buf_idx)
+#pragma omp parallel for default(shared) private(b, i, buf_start_idx, buf_idx)
   for (b = 0; b < nblocks; b++) {
     buf_start_idx = ((b)*nproma) % nlon;
     for (i = 0; i < nproma; i++) {
       buf_idx = (buf_start_idx + i) % nlon;
-      field[b][i] = buffer[buf_idx];
+      field_in[b*nproma+i] = buffer[buf_idx];
     }
   }
-
-  // Zero out the remainder of last block
-  /*
-  bsize = min(nproma, ngptot - (nblocks-1)*nproma);  // Size of the field block
-  printf("zeroing last block : %d \n",bsize);
-  for (i=bsize; i<nproma; i++) {
-    for (l=0; l<nlev; l++) {
-      field[nblocks-1][l][i] = 0.0;
-    }
-  }
-  */
-
 }
 
 
 void expand_1d_int(int *buffer, int *field_in, int nlon, int nproma, int ngptot, int nblocks)
 {
-  int b, l, i, buf_start_idx, buf_idx;
-  int (*field)[nproma] = (int (*)[nproma]) field_in;
+  int b, i, buf_start_idx, buf_idx;
 
-  #pragma omp parallel for default(shared) private(b, l, i, buf_start_idx, buf_idx)
+  #pragma omp parallel for default(shared) private(b, i, buf_start_idx, buf_idx)
   for (b = 0; b < nblocks; b++) {
     buf_start_idx = ((b)*nproma) % nlon;
     for (i = 0; i < nproma; i++) {
       buf_idx = (buf_start_idx + i) % nlon;
-      field[b][i] = buffer[buf_idx];
+      field_in[b*nproma+i] = buffer[buf_idx];
     }
   }
-
-  // Zero out the remainder of last block
-  /*
-  bsize = min(nproma, ngptot - (nblocks-1)*nproma);  // Size of the field block
-  printf("zeroing last block : %d \n",bsize);
-  for (i=bsize; i<nproma; i++) {
-    for (l=0; l<nlev; l++) {
-      field[nblocks-1][l][i] = 0;
-    }
-  }
-  */
 }
+
 
 void expand_2d(double *buffer_in, double *field_in, int nlon, int nlev, int nproma, int ngptot, int nblocks)
 {
   int b, l, i, buf_start_idx, buf_idx;
-  double (*buffer)[nlon] = (double (*)[nlon]) buffer_in;
-  double (*field)[nlev][nproma] = (double (*)[nlev][nproma]) field_in;
-  
+
   #pragma omp parallel for default(shared) private(b, buf_start_idx, buf_idx, l, i)
   for (b = 0; b < nblocks; b++) {
     buf_start_idx = ((b)*nproma) % nlon;
     for (i = 0; i < nproma; i++) {
-    for (l = 0; l < nlev; l++) {
-       buf_idx = (buf_start_idx + i) % nlon;
-       field[b][l][i] = buffer[l][buf_idx];       
-    }
-    }
-  }
-
-  // Zero out the remainder of last block
-  /*
-  bsize = min(nproma, ngptot - (nblocks-1)*nproma);  // Size of the field block
-  printf("zeroing last block : %d \n",bsize);
-  for (i=bsize; i<nproma; i++) {
-    for (l=0; l<nlev; l++) {
-      field[nblocks-1][l][i] = 0.0;
+      for (l = 0; l < nlev; l++) {
+        buf_idx = (buf_start_idx + i) % nlon;
+        field_in[b*nlev*nproma+l*nproma+i] = buffer_in[l*nlon+buf_idx];
+      }
     }
   }
-  */
-  
 }
-
 
 void expand_3d(double *buffer_in, double *field_in, int nlon, int nlev, int nclv, int nproma, int ngptot, int nblocks)
 {
   int b, l, c, i, buf_start_idx, buf_idx;
-  double (*buffer)[nlev][nlon] = (double (*)[nlev][nlon]) buffer_in;
-  double (*field)[nclv][nlev][nproma] = (double (*)[nclv][nlev][nproma]) field_in;
-  
+
 #pragma omp parallel for default(shared) private(b, buf_start_idx, buf_idx, l, i)
   for (b = 0; b < nblocks; b++) {
-    buf_start_idx = ((b)*nproma) % nlon;   
+    buf_start_idx = ((b)*nproma) % nlon;
     for (i = 0; i < nproma; i++) {
-    for (c = 0; c < nclv; c++) {
-    for (l = 0; l < nlev; l++) {
-      buf_idx = (buf_start_idx + i) % nlon;
-      field[b][c][l][i] = buffer[c][l][buf_idx];
-    }
-    }
-    }
-  }
-
-  // Zero out the remainder of last block
-  /*
-  bsize = min(nproma, ngptot - (nblocks-1)*nproma);  // Size of the field block
-  printf("zeroing last block : %d \n",bsize);
-  for (i=bsize; i<nproma; i++) {
-    for (l=0; l<nlev; l++) {
-      field[nblocks-1][l][i] = 0.0;
+      for (c = 0; c < nclv; c++) {
+        for (l = 0; l < nlev; l++) {
+          buf_idx = (buf_start_idx + i) % nlon;
+          field_in[b*nclv*nlev*nproma+c*nlev*nproma+l*nproma+i] = buffer_in[c*nlev*nlon+l*nlon+buf_idx];
+        }
+      }
     }
   }
-  */
-
 }
 
 #ifdef HAVE_SERIALBOX

--- a/src/cloudsc_cuda/cloudsc/load_state.cu
+++ b/src/cloudsc_cuda/cloudsc/load_state.cu
@@ -11,15 +11,40 @@
 #include "load_state.h"
 
 #include <math.h>
+#ifdef HAVE_SERIALBOX
 #include "serialbox-c/Serialbox.h"
+#endif
+#ifdef HAVE_HDF5
+#include "hdf5.h"
+#define INPUT_FILE "input.h5"
+#define REFERENCE_FILE "reference.h5"
+#endif
 
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 #define max(a, b) (((a) > (b)) ? (a) : (b))
 
+#ifdef HAVE_HDF5
+void read_hdf5_int(hid_t file_id, const char *name, int *field) {
+  hid_t dataset_id;
+  herr_t  status;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  status = H5Dread(dataset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, field);
+  status = H5Dclose(dataset_id);
+}
+
+void read_hdf5(hid_t file_id, const char *name, double *field) {
+  hid_t dataset_id;
+  herr_t  status;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, field);
+  status = H5Dclose(dataset_id);
+}
+#endif
 
 /* Query sizes and dimensions of state arrays */
 void query_state(int *klon, int *klev)
 {
+#ifdef HAVE_SERIALBOX
   serialboxSerializer_t* serializer = serialboxSerializerCreate(Read, "./data", "input", "Binary");
   serialboxMetainfo_t* globalMetainfo = serialboxSerializerGetGlobalMetainfo(serializer);
 
@@ -28,6 +53,17 @@ void query_state(int *klon, int *klev)
 
   serialboxMetainfoDestroy(globalMetainfo);
   serialboxSerializerDestroy(serializer);
+#endif
+#ifdef HAVE_HDF5
+  hid_t file_id, dataset_id;
+  herr_t  status;
+  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+  
+  read_hdf5_int(file_id, "/KLEV", klev);
+  read_hdf5_int(file_id, "/KLON", klon);
+  
+  status = H5Fclose(file_id);
+#endif
 }
 
 void expand_1d(double *buffer, double *field_in, int nlon, int nproma, int ngptot, int nblocks)
@@ -46,13 +82,14 @@ void expand_1d(double *buffer, double *field_in, int nlon, int nproma, int ngpto
 
   // Zero out the remainder of last block
   /*
-  int bsize = min(nproma, ngptot - (nblocks-1)*nproma);  // Size of the field block
+  bsize = min(nproma, ngptot - (nblocks-1)*nproma);  // Size of the field block
   printf("zeroing last block : %d \n",bsize);
   for (i=bsize; i<nproma; i++) {
-    field[nblocks-1][i] = 0.0;
+    for (l=0; l<nlev; l++) {
+      field[nblocks-1][l][i] = 0.0;
+    }
   }
   */
-  
 
 }
 
@@ -73,13 +110,14 @@ void expand_1d_int(int *buffer, int *field_in, int nlon, int nproma, int ngptot,
 
   // Zero out the remainder of last block
   /*
-  int bsize = min(nproma, ngptot - (nblocks-1)*nproma);  // Size of the field block
+  bsize = min(nproma, ngptot - (nblocks-1)*nproma);  // Size of the field block
   printf("zeroing last block : %d \n",bsize);
   for (i=bsize; i<nproma; i++) {
-    field[nblocks-1][i] = 0;
+    for (l=0; l<nlev; l++) {
+      field[nblocks-1][l][i] = 0;
+    }
   }
   */
-  
 }
 
 void expand_2d(double *buffer_in, double *field_in, int nlon, int nlev, int nproma, int ngptot, int nblocks)
@@ -101,7 +139,7 @@ void expand_2d(double *buffer_in, double *field_in, int nlon, int nlev, int npro
 
   // Zero out the remainder of last block
   /*
-  int bsize = min(nproma, ngptot - (nblocks-1)*nproma);  // Size of the field block
+  bsize = min(nproma, ngptot - (nblocks-1)*nproma);  // Size of the field block
   printf("zeroing last block : %d \n",bsize);
   for (i=bsize; i<nproma; i++) {
     for (l=0; l<nlev; l++) {
@@ -132,9 +170,9 @@ void expand_3d(double *buffer_in, double *field_in, int nlon, int nlev, int nclv
     }
   }
 
-  // Zero out the remainder of last block 
-   /* 
-  int bsize = min(nproma, ngptot - (nblocks-1)*nproma);  // Size of the field block
+  // Zero out the remainder of last block
+  /*
+  bsize = min(nproma, ngptot - (nblocks-1)*nproma);  // Size of the field block
   printf("zeroing last block : %d \n",bsize);
   for (i=bsize; i<nproma; i++) {
     for (l=0; l<nlev; l++) {
@@ -142,11 +180,10 @@ void expand_3d(double *buffer_in, double *field_in, int nlon, int nlev, int nclv
     }
   }
   */
-  
 
 }
 
-
+#ifdef HAVE_SERIALBOX
 void load_and_expand_1d(serialboxSerializer_t *serializer, serialboxSavepoint_t* savepoint,
     const char *name, int nlon, int nproma, int ngptot, int nblocks, double *field)
 {
@@ -186,30 +223,82 @@ void load_and_expand_3d(serialboxSerializer_t *serializer, serialboxSavepoint_t*
   serialboxSerializerRead(serializer, name, savepoint, buffer, strides, 3);
   expand_3d((double *)buffer, field, nlon, nlev, nclv, nproma, ngptot, nblocks);
 }
+#endif
+
+#if HAVE_HDF5
+void load_and_expand_1d(hid_t file_id, const char *name, int nlon, int nproma, int ngptot, int nblocks, double *field)
+{
+  double buffer[nlon];
+  int strides[1] = {1};
+  hid_t dataset_id;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  herr_t  status;
+  status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
+  status = H5Dclose(dataset_id);
+  expand_1d((double *)buffer, field, nlon, nproma, ngptot, nblocks);
+}
+
+void load_and_expand_1d_int(hid_t file_id, const char *name, int nlon, int nproma, int ngptot, int nblocks, int *field)
+{
+  int buffer[nlon];
+  int strides[1] = {1};
+  hid_t dataset_id;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  herr_t  status;
+  status = H5Dread(dataset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
+  status = H5Dclose(dataset_id);
+  expand_1d_int((int *)buffer, field, nlon, nproma, ngptot, nblocks);
+}
+
+void load_and_expand_2d(hid_t file_id, const char *name, int nlon, int nlev, int nproma, int ngptot, int nblocks, double *field)
+{
+  double buffer[nlev][nlon];
+  int strides[2] = {1, nlon};
+  hid_t dataset_id;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  herr_t  status;
+  status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
+  status = H5Dclose(dataset_id);
+  expand_2d((double *)buffer, field, nlon, nlev, nproma, ngptot, nblocks);
+}
+
+void load_and_expand_3d(hid_t file_id, const char *name, int nlon, int nlev, int nclv, int nproma, int ngptot, int nblocks, double *field)
+{
+  double buffer[nclv][nlev][nlon];
+  int strides[3] = {1, nlon, nlev*nlon};
+  hid_t dataset_id;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  herr_t  status;
+  status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
+  status = H5Dclose(dataset_id);
+  expand_3d((double *)buffer, field, nlon, nlev, nclv, nproma, ngptot, nblocks);
+}
+#endif
 
 /* Read input state into memory */
-void load_state(const int nlon, const int nlev, const int nclv, const int ngptot, const int nproma, 
-    double* ptsphy, double* plcrit_aer, double* picrit_aer,
-    double* pre_ice, double* pccn, double* pnice, double* pt, double* pq, 
-    double* tend_cml_t, double* tend_cml_q, double* tend_cml_a, double* tend_cml_cld,
-    double* tend_tmp_t, double* tend_tmp_q, double* tend_tmp_a, double* tend_tmp_cld,
-    double* pvfa, double* pvfl, double* pvfi, double* pdyna, double* pdynl, double* pdyni, 
-    double* phrsw, double* phrlw, double* pvervel, double* pap, double* paph, double* plsm,
-    int* ktype, double* plu, double* plude, double* psnde, double* pmfu,
-    double* pmfd, double* pa, double* pclv, double* psupsat, struct TECLDP* yrecldp,
-    double* rg, double* rd, double* rcpd, double* retv, double* rlvtt, double* rlstt, 
-    double* rlmlt, double* rtt, double* rv, double* r2es, double* r3les, double* r3ies,
-    double* r4les, double* r4ies, double* r5les, double* r5ies, double* r5alvcp, double* r5alscp,
-    double* ralvdcp, double* ralsdcp, double* ralfdcp, double* rtwat, 
-    double* rtice, double* rticecu, double* rtwat_rtice_r, double *rtwat_rticecu_r,
-    double* rkoop1, double* rkoop2 )
-{
+void load_state(const int nlon, const int nlev, const int nclv, const int ngptot, const int nproma,
+                double* ptsphy, double* plcrit_aer, double* picrit_aer,
+                double* pre_ice, double* pccn, double* pnice, double* pt, double* pq,
+                double* tend_cml_t, double* tend_cml_q, double* tend_cml_a, double* tend_cml_cld,
+                double* tend_tmp_t, double* tend_tmp_q, double* tend_tmp_a, double* tend_tmp_cld,
+                double* pvfa, double* pvfl, double* pvfi, double* pdyna, double* pdynl, double* pdyni,
+                double* phrsw, double* phrlw, double* pvervel, double* pap, double* paph, double* plsm,
+                int* ktype, double* plu, double* plude, double* psnde, double* pmfu,
+                double* pmfd, double* pa, double* pclv, double* psupsat, struct TECLDP* yrecldp,
+                double* rg, double* rd, double* rcpd, double* retv, double* rlvtt, double* rlstt,
+                double* rlmlt, double* rtt, double* rv, double* r2es, double* r3les, double* r3ies,
+                double* r4les, double* r4ies, double* r5les, double* r5ies, double* r5alvcp, double* r5alscp,
+                double* ralvdcp, double* ralsdcp, double* ralfdcp, double* rtwat,
+                double* rtice, double* rticecu, double* rtwat_rtice_r, double *rtwat_rticecu_r,
+                double* rkoop1, double* rkoop2) {
+
+  int nblocks = (ngptot / nproma) + min(ngptot % nproma, 1);
+
+#ifdef HAVE_SERIALBOX
   serialboxSerializer_t* serializer = serialboxSerializerCreate(Read, "./data", "input", "Binary");
   serialboxMetainfo_t* metainfo = serialboxSerializerGetGlobalMetainfo(serializer);
   serialboxSavepoint_t** savepoints = serialboxSerializerGetSavepointVector(serializer);
   serialboxSavepoint_t* savepoint = savepoints[0];
-
-  int nblocks = (ngptot / nproma) + min(ngptot % nproma, 1);
 
   load_and_expand_2d(serializer, savepoint, "PLCRIT_AER", nlon, nlev, nproma, ngptot, nblocks, plcrit_aer);
   load_and_expand_2d(serializer, savepoint, "PICRIT_AER", nlon, nlev, nproma, ngptot, nblocks, picrit_aer);
@@ -406,6 +495,209 @@ void load_state(const int nlon, const int nlev, const int nclv, const int ngptot
 
   serialboxSerializerDestroySavepointVector(savepoints, 1);
   serialboxSerializerDestroy(serializer);
+#endif
+
+#ifdef HAVE_HDF5
+
+  hid_t file_id, dataset_id;
+  herr_t  status;
+  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+
+  load_and_expand_2d(file_id, "PLCRIT_AER", nlon, nlev, nproma, ngptot, nblocks, plcrit_aer);
+  load_and_expand_2d(file_id, "PICRIT_AER", nlon, nlev, nproma, ngptot, nblocks, picrit_aer);
+  load_and_expand_2d(file_id, "PRE_ICE", nlon, nlev, nproma, ngptot, nblocks, pre_ice);
+  load_and_expand_2d(file_id, "PCCN", nlon, nlev, nproma, ngptot, nblocks, pccn);
+  load_and_expand_2d(file_id, "PNICE", nlon, nlev, nproma, ngptot, nblocks, pnice);
+  load_and_expand_2d(file_id, "PT", nlon, nlev, nproma, ngptot, nblocks, pt);
+  load_and_expand_2d(file_id, "PQ", nlon, nlev, nproma, ngptot, nblocks, pq);
+  load_and_expand_2d(file_id, "TENDENCY_CML_T", nlon, nlev, nproma, ngptot, nblocks, tend_cml_t);
+  load_and_expand_2d(file_id, "TENDENCY_CML_Q", nlon, nlev, nproma, ngptot, nblocks, tend_cml_q);
+  load_and_expand_2d(file_id, "TENDENCY_CML_A", nlon, nlev, nproma, ngptot, nblocks, tend_cml_a);
+  load_and_expand_3d(file_id, "TENDENCY_CML_CLD", nlon, nlev, nclv, nproma, ngptot, nblocks, tend_cml_cld);
+  load_and_expand_2d(file_id, "TENDENCY_TMP_T", nlon, nlev, nproma, ngptot, nblocks, tend_tmp_t);
+  load_and_expand_2d(file_id, "TENDENCY_TMP_Q", nlon, nlev, nproma, ngptot, nblocks, tend_tmp_q);
+  load_and_expand_2d(file_id, "TENDENCY_TMP_A", nlon, nlev, nproma, ngptot, nblocks, tend_tmp_a);
+  load_and_expand_3d(file_id, "TENDENCY_TMP_CLD", nlon, nlev, nclv, nproma, ngptot, nblocks, tend_tmp_cld);
+  load_and_expand_2d(file_id, "PVFA", nlon, nlev, nproma, ngptot, nblocks, pvfa);
+  load_and_expand_2d(file_id, "PVFL", nlon, nlev, nproma, ngptot, nblocks, pvfl);
+  load_and_expand_2d(file_id, "PVFI", nlon, nlev, nproma, ngptot, nblocks, pvfi);
+  load_and_expand_2d(file_id, "PDYNA", nlon, nlev, nproma, ngptot, nblocks, pdyna);
+  load_and_expand_2d(file_id, "PDYNL", nlon, nlev, nproma, ngptot, nblocks, pdynl);
+  load_and_expand_2d(file_id, "PDYNI", nlon, nlev, nproma, ngptot, nblocks, pdyni);
+  load_and_expand_2d(file_id, "PHRSW", nlon, nlev, nproma, ngptot, nblocks, phrsw);
+  load_and_expand_2d(file_id, "PHRLW", nlon, nlev, nproma, ngptot, nblocks, phrlw);
+  load_and_expand_2d(file_id, "PVERVEL", nlon, nlev, nproma, ngptot, nblocks, pvervel);
+  load_and_expand_2d(file_id, "PAP", nlon, nlev, nproma, ngptot, nblocks, pap);
+  load_and_expand_2d(file_id, "PAPH", nlon, nlev+1, nproma, ngptot, nblocks, paph);
+  load_and_expand_1d(file_id, "PLSM", nlon, nproma, ngptot, nblocks, plsm);
+  load_and_expand_1d_int(file_id, "KTYPE", nlon, nproma, ngptot, nblocks, ktype);
+  load_and_expand_2d(file_id, "PLU", nlon, nlev, nproma, ngptot, nblocks, plu);
+  load_and_expand_2d(file_id, "PLUDE", nlon, nlev, nproma, ngptot, nblocks, plude);
+  load_and_expand_2d(file_id, "PSNDE", nlon, nlev, nproma, ngptot, nblocks, psnde);
+  load_and_expand_2d(file_id, "PMFU", nlon, nlev, nproma, ngptot, nblocks, pmfu);
+  load_and_expand_2d(file_id, "PMFD", nlon, nlev, nproma, ngptot, nblocks, pmfd);
+  load_and_expand_2d(file_id, "PA", nlon, nlev, nproma, ngptot, nblocks, pa);
+  load_and_expand_3d(file_id, "PCLV", nlon, nlev, nclv, nproma, ngptot, nblocks, pclv);
+  load_and_expand_2d(file_id, "PSUPSAT", nlon, nlev, nproma, ngptot, nblocks, psupsat);
+  
+  read_hdf5(file_id, "/PTSPHY", ptsphy);
+  
+  read_hdf5(file_id, "/RG", rg);
+  read_hdf5(file_id, "/RD", rd);
+  read_hdf5(file_id, "/RCPD", rcpd); 
+  read_hdf5(file_id, "/RETV", retv);   
+  read_hdf5(file_id, "/RLVTT", rlvtt);  
+  read_hdf5(file_id, "/RLSTT", rlstt);  
+  read_hdf5(file_id, "/RLMLT", rlmlt);  
+  read_hdf5(file_id, "/RTT", rtt);  
+  read_hdf5(file_id, "/RV", rv);  
+  read_hdf5(file_id, "/R2ES", r2es);  
+  read_hdf5(file_id, "/R3LES", r3les);  
+  read_hdf5(file_id, "/R3IES", r3ies);  
+  read_hdf5(file_id, "/R4LES", r4les);  
+  read_hdf5(file_id, "/R4IES", r4ies);  
+  read_hdf5(file_id, "/R5LES", r5les);  
+  read_hdf5(file_id, "/R5IES", r5ies);  
+  read_hdf5(file_id, "/R5ALVCP", r5alvcp);  
+  read_hdf5(file_id, "/R5ALSCP", r5alscp);  
+  read_hdf5(file_id, "/RALVDCP", ralvdcp);  
+  read_hdf5(file_id, "/RALSDCP", ralsdcp);  
+  read_hdf5(file_id, "/RALFDCP", ralfdcp);  
+  read_hdf5(file_id, "/RTWAT", rtwat);  
+  read_hdf5(file_id, "/RTICE", rtice);  
+  read_hdf5(file_id, "/RTICECU", rticecu);  
+  read_hdf5(file_id, "/RTWAT_RTICE_R", rtwat_rtice_r);  
+  read_hdf5(file_id, "/RTWAT_RTICECU_R", rtwat_rticecu_r);  
+  read_hdf5(file_id, "/RKOOP1", rkoop1);  
+  read_hdf5(file_id, "/RKOOP2", rkoop2);  
+  
+  read_hdf5(file_id, "/YRECLDP_RAMID", &yrecldp->ramid);  
+  read_hdf5(file_id, "/YRECLDP_RCLDIFF", &yrecldp->rcldiff);  
+  read_hdf5(file_id, "/YRECLDP_RCLDIFF_CONVI", &yrecldp->rcldiff_convi);  
+  read_hdf5(file_id, "/YRECLDP_RCLCRIT", &yrecldp->rclcrit);  
+  read_hdf5(file_id, "/YRECLDP_RCLCRIT_SEA", &yrecldp->rclcrit_sea);  
+  read_hdf5(file_id, "/YRECLDP_RCLCRIT_LAND", &yrecldp->rclcrit_land);  
+  read_hdf5(file_id, "/YRECLDP_RKCONV", &yrecldp->rkconv);  
+  read_hdf5(file_id, "/YRECLDP_RPRC1", &yrecldp->rprc1);  
+  read_hdf5(file_id, "/YRECLDP_RPRC2", &yrecldp->rprc2);  
+  read_hdf5(file_id, "/YRECLDP_RCLDMAX", &yrecldp->rcldmax);  
+  read_hdf5(file_id, "/YRECLDP_RPECONS", &yrecldp->rpecons);  
+  read_hdf5(file_id, "/YRECLDP_RVRFACTOR", &yrecldp->rvrfactor);  
+  read_hdf5(file_id, "/YRECLDP_RPRECRHMAX", &yrecldp->rprecrhmax);  
+  read_hdf5(file_id, "/YRECLDP_RTAUMEL", &yrecldp->rtaumel);  
+  read_hdf5(file_id, "/YRECLDP_RAMIN", &yrecldp->ramin);  
+  read_hdf5(file_id, "/YRECLDP_RLMIN", &yrecldp->rlmin);  
+  read_hdf5(file_id, "/YRECLDP_RKOOPTAU", &yrecldp->rkooptau);  
+  read_hdf5(file_id, "/YRECLDP_RCLDTOPP", &yrecldp->rcldtopp);  
+  read_hdf5(file_id, "/YRECLDP_RLCRITSNOW", &yrecldp->rlcritsnow);  
+  read_hdf5(file_id, "/YRECLDP_RSNOWLIN1", &yrecldp->rsnowlin1);  
+  read_hdf5(file_id, "/YRECLDP_RSNOWLIN2", &yrecldp->rsnowlin2);  
+  read_hdf5(file_id, "/YRECLDP_RICEHI1", &yrecldp->ricehi1);  
+  read_hdf5(file_id, "/YRECLDP_RICEHI2", &yrecldp->ricehi2);  
+  read_hdf5(file_id, "/YRECLDP_RICEINIT", &yrecldp->riceinit);  
+  read_hdf5(file_id, "/YRECLDP_RVICE", &yrecldp->rvice);  
+  read_hdf5(file_id, "/YRECLDP_RVRAIN", &yrecldp->rvrain);  
+  read_hdf5(file_id, "/YRECLDP_RVSNOW", &yrecldp->rvsnow);  
+  read_hdf5(file_id, "/YRECLDP_RTHOMO", &yrecldp->rthomo);  
+  read_hdf5(file_id, "/YRECLDP_RCOVPMIN", &yrecldp->rcovpmin);  
+  read_hdf5(file_id, "/YRECLDP_RCCN", &yrecldp->rccn);  
+  read_hdf5(file_id, "/YRECLDP_RNICE", &yrecldp->rnice);  
+  read_hdf5(file_id, "/YRECLDP_RCCNOM", &yrecldp->rccnom);  
+  read_hdf5(file_id, "/YRECLDP_RCCNSS", &yrecldp->rccnss);  
+  read_hdf5(file_id, "/YRECLDP_RCCNSU", &yrecldp->rccnsu);  
+  read_hdf5(file_id, "/YRECLDP_RCLDTOPCF", &yrecldp->rcldtopcf);  
+  read_hdf5(file_id, "/YRECLDP_RDEPLIQREFRATE", &yrecldp->rdepliqrefrate);  
+  read_hdf5(file_id, "/YRECLDP_RDEPLIQREFDEPTH", &yrecldp->rdepliqrefdepth);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KKAac", &yrecldp->rcl_kkaac);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KKBac", &yrecldp->rcl_kkbac);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KKAau", &yrecldp->rcl_kkaau);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KKBauq", &yrecldp->rcl_kkbauq);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KKBaun", &yrecldp->rcl_kkbaun);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KK_cloud_num_sea", &yrecldp->rcl_kk_cloud_num_sea);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KK_cloud_num_land", &yrecldp->rcl_kk_cloud_num_land);  
+  read_hdf5(file_id, "/YRECLDP_RCL_AI", &yrecldp->rcl_ai);  
+  read_hdf5(file_id, "/YRECLDP_RCL_BI", &yrecldp->rcl_bi);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CI", &yrecldp->rcl_ci);  
+  read_hdf5(file_id, "/YRECLDP_RCL_DI", &yrecldp->rcl_di);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X1I", &yrecldp->rcl_x1i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X2I", &yrecldp->rcl_x2i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X3I", &yrecldp->rcl_x3i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X4I", &yrecldp->rcl_x4i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST1I", &yrecldp->rcl_const1i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST2I", &yrecldp->rcl_const2i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST3I", &yrecldp->rcl_const3i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST4I", &yrecldp->rcl_const4i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST5I", &yrecldp->rcl_const5i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST6I", &yrecldp->rcl_const6i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_APB1", &yrecldp->rcl_apb1);  
+  read_hdf5(file_id, "/YRECLDP_RCL_APB2", &yrecldp->rcl_apb2);  
+  read_hdf5(file_id, "/YRECLDP_RCL_APB3", &yrecldp->rcl_apb3);  
+  read_hdf5(file_id, "/YRECLDP_RCL_AS", &yrecldp->rcl_as);  
+  read_hdf5(file_id, "/YRECLDP_RCL_BS", &yrecldp->rcl_bs);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CS", &yrecldp->rcl_cs);  
+  read_hdf5(file_id, "/YRECLDP_RCL_DS", &yrecldp->rcl_ds);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X1S", &yrecldp->rcl_x1s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X2S", &yrecldp->rcl_x2s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X3S", &yrecldp->rcl_x3s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X4S", &yrecldp->rcl_x4s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST1S", &yrecldp->rcl_const1s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST2S", &yrecldp->rcl_const2s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST3S", &yrecldp->rcl_const3s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST4S", &yrecldp->rcl_const4s);   
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST5S", &yrecldp->rcl_const5s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST6S", &yrecldp->rcl_const6s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST7S", &yrecldp->rcl_const7s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST8S", &yrecldp->rcl_const8s);   
+  read_hdf5(file_id, "/YRECLDP_RDENSWAT", &yrecldp->rdenswat);  
+  read_hdf5(file_id, "/YRECLDP_RDENSREF", &yrecldp->rdensref);  
+  read_hdf5(file_id, "/YRECLDP_RCL_AR", &yrecldp->rcl_ar);  
+  read_hdf5(file_id, "/YRECLDP_RCL_BR", &yrecldp->rcl_br);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CR", &yrecldp->rcl_cr);  
+  read_hdf5(file_id, "/YRECLDP_RCL_DR", &yrecldp->rcl_dr);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X1R", &yrecldp->rcl_x1r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X2R", &yrecldp->rcl_x2r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X4R", &yrecldp->rcl_x4r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KA273", &yrecldp->rcl_ka273);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CDENOM1", &yrecldp->rcl_cdenom1);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CDENOM2", &yrecldp->rcl_cdenom2);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CDENOM3", &yrecldp->rcl_cdenom3);  
+  read_hdf5(file_id, "/YRECLDP_RCL_SCHMIDT", &yrecldp->rcl_schmidt);  
+  read_hdf5(file_id, "/YRECLDP_RCL_DYNVISC", &yrecldp->rcl_dynvisc);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST1R", &yrecldp->rcl_const1r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST2R", &yrecldp->rcl_const2r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST3R", &yrecldp->rcl_const3r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST4R", &yrecldp->rcl_const4r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_FAC1", &yrecldp->rcl_fac1);  
+  read_hdf5(file_id, "/YRECLDP_RCL_FAC2", &yrecldp->rcl_fac2);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST5R", &yrecldp->rcl_const5r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST6R", &yrecldp->rcl_const6r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_FZRAB", &yrecldp->rcl_fzrab);  
+  read_hdf5(file_id, "/YRECLDP_RCL_FZRBB", &yrecldp->rcl_fzrbb);
+  read_hdf5_int(file_id, "/YRECLDP_LCLDEXTRA", &yrecldp->lcldextra); // Bool
+  read_hdf5_int(file_id, "/YRECLDP_LCLDBUDGET", &yrecldp->lcldbudget); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_NSSOPT", &yrecldp->nssopt);   
+  read_hdf5_int(file_id, "/YRECLDP_NCLDTOP", &yrecldp->ncldtop);  
+  read_hdf5_int(file_id, "/YRECLDP_NAECLBC", &yrecldp->naeclbc);  
+  read_hdf5_int(file_id, "/YRECLDP_NAECLDU", &yrecldp->naecldu);  
+  read_hdf5_int(file_id, "/YRECLDP_NAECLOM", &yrecldp->naeclom);  
+  read_hdf5_int(file_id, "/YRECLDP_NAECLSS", &yrecldp->naeclss);  
+  read_hdf5_int(file_id, "/YRECLDP_NAECLSU", &yrecldp->naeclsu);  
+  read_hdf5_int(file_id, "/YRECLDP_NCLDDIAG", &yrecldp->nclddiag);  
+  read_hdf5_int(file_id, "/YRECLDP_NAERCLD", &yrecldp->naercld);  
+  read_hdf5_int(file_id, "/YRECLDP_LAERLIQAUTOLSP", &yrecldp->laerliqautolsp); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_LAERLIQAUTOCP", &yrecldp->laerliqautocp); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_LAERLIQAUTOCPB", &yrecldp->laerliqautocpb); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_LAERLIQCOLL", &yrecldp->laerliqcoll); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_LAERICESED", &yrecldp->laericesed); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_LAERICEAUTO", &yrecldp->laericeauto); // Bool 
+  read_hdf5(file_id, "/YRECLDP_NSHAPEP", &yrecldp->nshapep);  
+  read_hdf5(file_id, "/YRECLDP_NSHAPEQ", &yrecldp->nshapeq);  
+  read_hdf5_int(file_id, "/YRECLDP_NBETA", &yrecldp->nbeta);  
+  
+  status = H5Fclose(file_id);
+
+#endif
+
 }
 
 
@@ -417,12 +709,14 @@ void load_reference(const int nlon, const int nlev, const int nclv, const int ng
 		    double *pfsqltur, double *pfsqitur, double *pfplsl, double *pfplsn, double *pfhpsl, double *pfhpsn,
 		    double *tend_loc_a, double *tend_loc_q, double *tend_loc_t, double *tend_loc_cld)
 {
+
+  int nblocks = (ngptot / nproma) + min(ngptot % nproma, 1);
+
+#ifdef HAVE_SERIALBOX
   serialboxSerializer_t* serializer = serialboxSerializerCreate(Read, "./data", "reference", "Binary");
   serialboxMetainfo_t* metainfo = serialboxSerializerGetGlobalMetainfo(serializer);
   serialboxSavepoint_t** savepoints = serialboxSerializerGetSavepointVector(serializer);
   serialboxSavepoint_t* savepoint = savepoints[0];
-
-  int nblocks = (ngptot / nproma) + min(ngptot % nproma, 1);
 
   load_and_expand_2d(serializer, savepoint, "PLUDE", nlon, nlev, nproma, ngptot, nblocks, plude);
   load_and_expand_2d(serializer, savepoint, "PCOVPTOT", nlon, nlev, nproma, ngptot, nblocks, pcovptot);
@@ -448,4 +742,37 @@ void load_reference(const int nlon, const int nlev, const int nclv, const int ng
 
   serialboxSerializerDestroySavepointVector(savepoints, 1);
   serialboxSerializerDestroy(serializer);
+#endif
+
+#ifdef HAVE_HDF5
+
+  hid_t file_id, dataset_id;
+  herr_t  status;
+  file_id = H5Fopen(REFERENCE_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+
+  load_and_expand_2d(file_id, "PLUDE", nlon, nlev, nproma, ngptot, nblocks, plude);
+  load_and_expand_2d(file_id, "PCOVPTOT", nlon, nlev, nproma, ngptot, nblocks, pcovptot);
+  load_and_expand_1d(file_id, "PRAINFRAC_TOPRFZ", nlon, nproma, ngptot, nblocks, prainfrac_toprfz);
+  load_and_expand_2d(file_id, "PFSQLF", nlon, nlev+1, nproma, ngptot, nblocks, pfsqlf);
+  load_and_expand_2d(file_id, "PFSQIF", nlon, nlev+1, nproma, ngptot, nblocks, pfsqif);
+  load_and_expand_2d(file_id, "PFCQLNG", nlon, nlev+1, nproma, ngptot, nblocks, pfcqlng);
+  load_and_expand_2d(file_id, "PFCQNNG", nlon, nlev+1, nproma, ngptot, nblocks, pfcqnng);
+  load_and_expand_2d(file_id, "PFSQRF", nlon, nlev+1, nproma, ngptot, nblocks, pfsqrf);
+  load_and_expand_2d(file_id, "PFSQSF", nlon, nlev+1, nproma, ngptot, nblocks, pfsqsf);
+  load_and_expand_2d(file_id, "PFCQRNG", nlon, nlev+1, nproma, ngptot, nblocks, pfcqrng);
+  load_and_expand_2d(file_id, "PFCQSNG", nlon, nlev+1, nproma, ngptot, nblocks, pfcqsng);
+  load_and_expand_2d(file_id, "PFSQLTUR", nlon, nlev+1, nproma, ngptot, nblocks, pfsqltur);
+  load_and_expand_2d(file_id, "PFSQITUR", nlon, nlev+1, nproma, ngptot, nblocks, pfsqitur);
+  load_and_expand_2d(file_id, "PFPLSL", nlon, nlev+1, nproma, ngptot, nblocks, pfplsl);
+  load_and_expand_2d(file_id, "PFPLSN", nlon, nlev+1, nproma, ngptot, nblocks, pfplsn);
+  load_and_expand_2d(file_id, "PFHPSL", nlon, nlev+1, nproma, ngptot, nblocks, pfhpsl);
+  load_and_expand_2d(file_id, "PFHPSN", nlon, nlev+1, nproma, ngptot, nblocks, pfhpsn);
+  load_and_expand_2d(file_id, "TENDENCY_LOC_T", nlon, nlev, nproma, ngptot, nblocks, tend_loc_t);
+  load_and_expand_2d(file_id, "TENDENCY_LOC_Q", nlon, nlev, nproma, ngptot, nblocks, tend_loc_q);
+  load_and_expand_2d(file_id, "TENDENCY_LOC_A", nlon, nlev, nproma, ngptot, nblocks, tend_loc_a);
+  load_and_expand_3d(file_id, "TENDENCY_LOC_CLD", nlon, nlev, nclv, nproma, ngptot, nblocks, tend_loc_cld);
+
+  status = H5Fclose(file_id);
+#endif
+
 }

--- a/src/cloudsc_hip/CMakeLists.txt
+++ b/src/cloudsc_hip/CMakeLists.txt
@@ -9,7 +9,7 @@
 # Define this dwarf variant as an ECBuild feature
 ecbuild_add_option( FEATURE CLOUDSC_HIP
 	DESCRIPTION "Build the HIP version CLOUDSC using Serialbox" DEFAULT ON
-	CONDITION Serialbox_FOUND AND HAVE_HIP
+	CONDITION (Serialbox_FOUND OR HDF5_FOUND) AND HAVE_HIP
 )
 
 if( HAVE_CLOUDSC_HIP )
@@ -37,13 +37,16 @@ if( HAVE_CLOUDSC_HIP )
             $<INSTALL_INTERFACE:include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cloudsc>
         PUBLIC_LIBS
-    	    hip::device
-            Serialbox::Serialbox_C
+            hip::device
+	    $<${HAVE_HDF5}:hdf5::hdf5>
+            $<${HAVE_SERIALBOX}:Serialbox::Serialbox_C>
             $<${HAVE_OMP}:OpenMP::OpenMP_C>
+        DEFINITIONS
+            ${CLOUDSC_DEFINITIONS}
     )
 
     target_include_directories(dwarf-cloudsc-hip-lib PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cloudsc>)
-    target_link_libraries(dwarf-cloudsc-hip-lib PUBLIC hip::device Serialbox::Serialbox_C $<${HAVE_OMP}:OpenMP::OpenMP_C>)
+    target_link_libraries(dwarf-cloudsc-hip-lib PUBLIC hip::device $<${HAVE_HDF5}:hdf5::hdf5> $<${HAVE_SERIALBOX}:Serialbox::Serialbox_C> $<${HAVE_OMP}:OpenMP::OpenMP_C>)
 
     if (NOT DEFINED CMAKE_HIP_ARCHITECTURES)
       message(WARNING "No HIP architecture is set! ('CMAKE_HIP_ARCHITECTURES' is not defined)")
@@ -86,13 +89,16 @@ if( HAVE_CLOUDSC_HIP )
             $<INSTALL_INTERFACE:include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cloudsc>
         PUBLIC_LIBS
-    	    hip::device
-            Serialbox::Serialbox_C
+            hip::device
+            $<${HAVE_HDF5}:hdf5::hdf5>
+            $<${HAVE_SERIALBOX}:Serialbox::Serialbox_C>
             $<${HAVE_OMP}:OpenMP::OpenMP_C>
+        DEFINITIONS
+            ${CLOUDSC_DEFINITIONS}
     )
 
     target_include_directories(dwarf-cloudsc-hip-hoist-lib PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cloudsc>)
-    target_link_libraries(dwarf-cloudsc-hip-hoist-lib PUBLIC hip::device Serialbox::Serialbox_C $<${HAVE_OMP}:OpenMP::OpenMP_C>)
+    target_link_libraries(dwarf-cloudsc-hip-hoist-lib PUBLIC hip::device $<${HAVE_HDF5}:hdf5::hdf5> $<${HAVE_SERIALBOX}:Serialbox::Serialbox_C> $<${HAVE_OMP}:OpenMP::OpenMP_C>)
 
     if (NOT DEFINED CMAKE_HIP_ARCHITECTURES)
       message(WARNING "No HIP architecture is set! ('CMAKE_HIP_ARCHITECTURES' is not defined)")
@@ -135,13 +141,16 @@ if( HAVE_CLOUDSC_HIP )
             $<INSTALL_INTERFACE:include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cloudsc>
         PUBLIC_LIBS
-    	    hip::device
-            Serialbox::Serialbox_C
+            hip::device
+            $<${HAVE_HDF5}:hdf5::hdf5>
+            $<${HAVE_SERIALBOX}:Serialbox::Serialbox_C>
             $<${HAVE_OMP}:OpenMP::OpenMP_C>
+        DEFINITIONS
+            ${CLOUDSC_DEFINITIONS}
     )
 
     target_include_directories(dwarf-cloudsc-hip-k-caching-lib PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cloudsc>)
-    target_link_libraries(dwarf-cloudsc-hip-k-caching-lib PUBLIC hip::device Serialbox::Serialbox_C $<${HAVE_OMP}:OpenMP::OpenMP_C>)
+    target_link_libraries(dwarf-cloudsc-hip-k-caching-lib PUBLIC hip::device $<${HAVE_HDF5}:hdf5::hdf5> $<${HAVE_SERIALBOX}:Serialbox::Serialbox_C> $<${HAVE_OMP}:OpenMP::OpenMP_C>)
 
     if (NOT DEFINED CMAKE_HIP_ARCHITECTURES)
       message(WARNING "No HIP architecture is set! ('CMAKE_HIP_ARCHITECTURES' is not defined)")
@@ -164,8 +173,17 @@ if( HAVE_CLOUDSC_HIP )
     )
     ## 
     
-    # Create symlink for the input data
-    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../data ${CMAKE_CURRENT_BINARY_DIR}/../../../data )
+ # Create symlink for the input data
+ if( HAVE_SERIALBOX )
+   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+       ${CMAKE_CURRENT_SOURCE_DIR}/../../data ${CMAKE_CURRENT_BINARY_DIR}/../../../data )
+ endif()
+    
+ if( HAVE_HDF5 )
+   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+       ${CMAKE_CURRENT_SOURCE_DIR}/../../config-files/input.h5 ${CMAKE_CURRENT_BINARY_DIR}/../../../input.h5 )
+   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+       ${CMAKE_CURRENT_SOURCE_DIR}/../../config-files/reference.h5 ${CMAKE_CURRENT_BINARY_DIR}/../../../reference.h5 )
+ endif()
 
 endif()

--- a/src/cloudsc_hip/cloudsc/cloudsc_validate.cpp
+++ b/src/cloudsc_hip/cloudsc/cloudsc_validate.cpp
@@ -50,8 +50,6 @@ void validate_1d(const char *name, double * v_ref, double * v_field, int nlon, i
   /* Computes and prints errors in the "L2 norm sense" */
   int b, bsize, jk;
   double zminval, zmaxval, zdiff, zmaxerr, zerrsum, zsum, zrelerr, zavgpgp;
-  //double (*field)[nlon] = (double (*)[nlon]) v_field;
-  //double (*reference)[nlon] = (double (*)[nlon]) v_ref;
 
   zminval = +DBL_MAX;
   zmaxval = -DBL_MAX;
@@ -59,8 +57,8 @@ void validate_1d(const char *name, double * v_ref, double * v_field, int nlon, i
   zerrsum = 0.0;
   zsum = 0.0;
 
-//  #pragma omp parallel for default(shared) private(b, bsize, jk)		\
-//    reduction(min:zminval) reduction(max:zmaxval,zmaxerr) reduction(+:zerrsum,zsum)
+  #pragma omp parallel for default(shared) private(b, bsize, jk)		\
+    reduction(min:zminval) reduction(max:zmaxval,zmaxerr) reduction(+:zerrsum,zsum)
   for (b = 0; b < nblocks; b++) {
     bsize = min(nlon, ngptot - b*nlon);  // field block size
     for (jk = 0; jk < bsize; jk++) {
@@ -84,8 +82,6 @@ void validate_2d(const char *name, double *v_ref, double *v_field, int nlon, int
   /* Computes and prints errors in the "L2 norm sense" */
   int b, bsize, jl, jk;
   double zminval, zmaxval, zdiff, zmaxerr, zerrsum, zsum, zrelerr, zavgpgp;
-//  double (*field)[nlev][nlon] = (double (*)[nlev][nlon]) v_field;
-//  double (*reference)[nlev][nlon] = (double (*)[nlev][nlon]) v_ref;
 
   zminval = +DBL_MAX;
   zmaxval = -DBL_MAX;
@@ -93,9 +89,8 @@ void validate_2d(const char *name, double *v_ref, double *v_field, int nlon, int
   zerrsum = 0.0;
   zsum = 0.0;
 
-//  #pragma omp parallel for default(shared) private(b, bsize, jl, jk) \
-//    reduction(min:zminval) reduction(max:zmaxval,zmaxerr) reduction(+:zerrsum,zsum)
-
+  #pragma omp parallel for default(shared) private(b, bsize, jl, jk) \
+    reduction(min:zminval) reduction(max:zmaxval,zmaxerr) reduction(+:zerrsum,zsum)
   for (b = 0; b < nblocks; b++) {
     bsize = min(nlon, ngptot - b*nlon);  // field block size
     for (jl = 0; jl < nlev; jl++) {
@@ -111,7 +106,6 @@ void validate_2d(const char *name, double *v_ref, double *v_field, int nlon, int
       }
     }
   }
-
   zavgpgp = zerrsum / (double) ngptot;
   print_error(name, zminval, zmaxval, zmaxerr, zerrsum, zsum, zavgpgp, 2);
 }
@@ -123,8 +117,6 @@ void validate_3d(const char *name, double *v_ref, double *v_field, int nlon,
   /* Computes and prints errors in the "L2 norm sense" */
   int b, bsize, jl, jk, jm;
   double zminval, zmaxval, zdiff, zmaxerr, zerrsum, zsum, zrelerr, zavgpgp;
-//  double (*field)[nclv][nlev][nlon] = (double (*)[nclv][nlev][nlon]) v_field;
-//  double (*reference)[nclv][nlev][nlon] = (double (*)[nclv][nlev][nlon]) v_ref;
 
   zminval = +DBL_MAX;
   zmaxval = -DBL_MAX;
@@ -132,8 +124,8 @@ void validate_3d(const char *name, double *v_ref, double *v_field, int nlon,
   zerrsum = 0.0;
   zsum = 0.0;
 
-//  #pragma omp parallel for default(shared) private(b, bsize, jl, jk, jm) \
-//    reduction(min:zminval) reduction(max:zmaxval,zmaxerr) reduction(+:zerrsum,zsum)
+  #pragma omp parallel for default(shared) private(b, bsize, jl, jk, jm) \
+    reduction(min:zminval) reduction(max:zmaxval,zmaxerr) reduction(+:zerrsum,zsum)
   for (b = 0; b < nblocks; b++) {
     bsize = min(nlon, ngptot - b*nlon);  // field block size
     for (jm = 0; jm < nclv; jm++) {
@@ -150,7 +142,7 @@ void validate_3d(const char *name, double *v_ref, double *v_field, int nlon,
 	}
       }
     }
-  }
+  }  
   zavgpgp = zerrsum / (double) ngptot;
   print_error(name, zminval, zmaxval, zmaxerr, zerrsum, zsum, zavgpgp, 2);
 }

--- a/src/cloudsc_hip/cloudsc/load_state.cpp
+++ b/src/cloudsc_hip/cloudsc/load_state.cpp
@@ -9,17 +9,42 @@
  */
 
 #include "load_state.h"
-#include <iostream>
 
 #include <math.h>
+#ifdef HAVE_SERIALBOX
 #include "serialbox-c/Serialbox.h"
+#endif
+#ifdef HAVE_HDF5
+#include "hdf5.h"
+#define INPUT_FILE "input.h5"
+#define REFERENCE_FILE "reference.h5"
+#endif
 
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 #define max(a, b) (((a) > (b)) ? (a) : (b))
 
+#ifdef HAVE_HDF5
+void read_hdf5_int(hid_t file_id, const char *name, int *field) {
+  hid_t dataset_id;
+  herr_t  status;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  status = H5Dread(dataset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, field);
+  status = H5Dclose(dataset_id);
+}
+
+void read_hdf5(hid_t file_id, const char *name, double *field) {
+  hid_t dataset_id;
+  herr_t  status;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, field);
+  status = H5Dclose(dataset_id);
+}
+#endif
+
 /* Query sizes and dimensions of state arrays */
 void query_state(int *klon, int *klev)
 {
+#ifdef HAVE_SERIALBOX
   serialboxSerializer_t* serializer = serialboxSerializerCreate(Read, "./data", "input", "Binary");
   serialboxMetainfo_t* globalMetainfo = serialboxSerializerGetGlobalMetainfo(serializer);
 
@@ -28,6 +53,17 @@ void query_state(int *klon, int *klev)
 
   serialboxMetainfoDestroy(globalMetainfo);
   serialboxSerializerDestroy(serializer);
+#endif
+#ifdef HAVE_HDF5
+  hid_t file_id, dataset_id;
+  herr_t  status;
+  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+  
+  read_hdf5_int(file_id, "/KLEV", klev);
+  read_hdf5_int(file_id, "/KLON", klon);
+  
+  status = H5Fclose(file_id);
+#endif
 }
 
 void expand_1d(double *buffer, double *field_in, int nlon, int nproma, int ngptot, int nblocks)
@@ -94,7 +130,7 @@ void expand_3d(double *buffer_in, double *field_in, int nlon, int nlev, int nclv
   }
 }
 
-
+#ifdef HAVE_SERIALBOX
 void load_and_expand_1d(serialboxSerializer_t *serializer, serialboxSavepoint_t* savepoint,
     const char *name, int nlon, int nproma, int ngptot, int nblocks, double *field)
 {
@@ -134,31 +170,82 @@ void load_and_expand_3d(serialboxSerializer_t *serializer, serialboxSavepoint_t*
   serialboxSerializerRead(serializer, name, savepoint, buffer, strides, 3);
   expand_3d((double *)buffer, field, nlon, nlev, nclv, nproma, ngptot, nblocks);
 }
+#endif
 
+#if HAVE_HDF5
+void load_and_expand_1d(hid_t file_id, const char *name, int nlon, int nproma, int ngptot, int nblocks, double *field)
+{
+  double buffer[nlon];
+  int strides[1] = {1};
+  hid_t dataset_id;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  herr_t  status;
+  status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
+  status = H5Dclose(dataset_id);
+  expand_1d((double *)buffer, field, nlon, nproma, ngptot, nblocks);
+}
+
+void load_and_expand_1d_int(hid_t file_id, const char *name, int nlon, int nproma, int ngptot, int nblocks, int *field)
+{
+  int buffer[nlon];
+  int strides[1] = {1};
+  hid_t dataset_id;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  herr_t  status;
+  status = H5Dread(dataset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
+  status = H5Dclose(dataset_id);
+  expand_1d_int((int *)buffer, field, nlon, nproma, ngptot, nblocks);
+}
+
+void load_and_expand_2d(hid_t file_id, const char *name, int nlon, int nlev, int nproma, int ngptot, int nblocks, double *field)
+{
+  double buffer[nlev][nlon];
+  int strides[2] = {1, nlon};
+  hid_t dataset_id;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  herr_t  status;
+  status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
+  status = H5Dclose(dataset_id);
+  expand_2d((double *)buffer, field, nlon, nlev, nproma, ngptot, nblocks);
+}
+
+void load_and_expand_3d(hid_t file_id, const char *name, int nlon, int nlev, int nclv, int nproma, int ngptot, int nblocks, double *field)
+{
+  double buffer[nclv][nlev][nlon];
+  int strides[3] = {1, nlon, nlev*nlon};
+  hid_t dataset_id;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  herr_t  status;
+  status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
+  status = H5Dclose(dataset_id);
+  expand_3d((double *)buffer, field, nlon, nlev, nclv, nproma, ngptot, nblocks);
+}
+#endif
 
 /* Read input state into memory */
-void load_state(const int nlon, const int nlev, const int nclv, const int ngptot, const int nproma, 
-    double* ptsphy, double* plcrit_aer, double* picrit_aer,
-    double* pre_ice, double* pccn, double* pnice, double* pt, double* pq, 
-    double* tend_cml_t, double* tend_cml_q, double* tend_cml_a, double* tend_cml_cld,
-    double* tend_tmp_t, double* tend_tmp_q, double* tend_tmp_a, double* tend_tmp_cld,
-    double* pvfa, double* pvfl, double* pvfi, double* pdyna, double* pdynl, double* pdyni, 
-    double* phrsw, double* phrlw, double* pvervel, double* pap, double* paph, double* plsm,
-    int* ktype, double* plu, double* plude, double* psnde, double* pmfu,
-    double* pmfd, double* pa, double* pclv, double* psupsat, struct TECLDP* yrecldp,
-    double* rg, double* rd, double* rcpd, double* retv, double* rlvtt, double* rlstt, 
-    double* rlmlt, double* rtt, double* rv, double* r2es, double* r3les, double* r3ies,
-    double* r4les, double* r4ies, double* r5les, double* r5ies, double* r5alvcp, double* r5alscp,
-    double* ralvdcp, double* ralsdcp, double* ralfdcp, double* rtwat, 
-    double* rtice, double* rticecu, double* rtwat_rtice_r, double *rtwat_rticecu_r,
-    double* rkoop1, double* rkoop2 )
-{
+void load_state(const int nlon, const int nlev, const int nclv, const int ngptot, const int nproma,
+                double* ptsphy, double* plcrit_aer, double* picrit_aer,
+                double* pre_ice, double* pccn, double* pnice, double* pt, double* pq,
+                double* tend_cml_t, double* tend_cml_q, double* tend_cml_a, double* tend_cml_cld,
+                double* tend_tmp_t, double* tend_tmp_q, double* tend_tmp_a, double* tend_tmp_cld,
+                double* pvfa, double* pvfl, double* pvfi, double* pdyna, double* pdynl, double* pdyni,
+                double* phrsw, double* phrlw, double* pvervel, double* pap, double* paph, double* plsm,
+                int* ktype, double* plu, double* plude, double* psnde, double* pmfu,
+                double* pmfd, double* pa, double* pclv, double* psupsat, struct TECLDP* yrecldp,
+                double* rg, double* rd, double* rcpd, double* retv, double* rlvtt, double* rlstt,
+                double* rlmlt, double* rtt, double* rv, double* r2es, double* r3les, double* r3ies,
+                double* r4les, double* r4ies, double* r5les, double* r5ies, double* r5alvcp, double* r5alscp,
+                double* ralvdcp, double* ralsdcp, double* ralfdcp, double* rtwat,
+                double* rtice, double* rticecu, double* rtwat_rtice_r, double *rtwat_rticecu_r,
+                double* rkoop1, double* rkoop2) {
+
+  int nblocks = (ngptot / nproma) + min(ngptot % nproma, 1);
+
+#ifdef HAVE_SERIALBOX
   serialboxSerializer_t* serializer = serialboxSerializerCreate(Read, "./data", "input", "Binary");
   serialboxMetainfo_t* metainfo = serialboxSerializerGetGlobalMetainfo(serializer);
   serialboxSavepoint_t** savepoints = serialboxSerializerGetSavepointVector(serializer);
   serialboxSavepoint_t* savepoint = savepoints[0];
-
-  int nblocks = (ngptot / nproma) + min(ngptot % nproma, 1);
 
   load_and_expand_2d(serializer, savepoint, "PLCRIT_AER", nlon, nlev, nproma, ngptot, nblocks, plcrit_aer);
   load_and_expand_2d(serializer, savepoint, "PICRIT_AER", nlon, nlev, nproma, ngptot, nblocks, picrit_aer);
@@ -355,7 +442,212 @@ void load_state(const int nlon, const int nlev, const int nclv, const int ngptot
 
   serialboxSerializerDestroySavepointVector(savepoints, 1);
   serialboxSerializerDestroy(serializer);
+#endif
+
+#ifdef HAVE_HDF5
+
+  hid_t file_id, dataset_id;
+  herr_t  status;
+  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+
+  load_and_expand_2d(file_id, "PLCRIT_AER", nlon, nlev, nproma, ngptot, nblocks, plcrit_aer);
+  load_and_expand_2d(file_id, "PICRIT_AER", nlon, nlev, nproma, ngptot, nblocks, picrit_aer);
+  load_and_expand_2d(file_id, "PRE_ICE", nlon, nlev, nproma, ngptot, nblocks, pre_ice);
+  load_and_expand_2d(file_id, "PCCN", nlon, nlev, nproma, ngptot, nblocks, pccn);
+  load_and_expand_2d(file_id, "PNICE", nlon, nlev, nproma, ngptot, nblocks, pnice);
+  load_and_expand_2d(file_id, "PT", nlon, nlev, nproma, ngptot, nblocks, pt);
+  load_and_expand_2d(file_id, "PQ", nlon, nlev, nproma, ngptot, nblocks, pq);
+  load_and_expand_2d(file_id, "TENDENCY_CML_T", nlon, nlev, nproma, ngptot, nblocks, tend_cml_t);
+  load_and_expand_2d(file_id, "TENDENCY_CML_Q", nlon, nlev, nproma, ngptot, nblocks, tend_cml_q);
+  load_and_expand_2d(file_id, "TENDENCY_CML_A", nlon, nlev, nproma, ngptot, nblocks, tend_cml_a);
+  load_and_expand_3d(file_id, "TENDENCY_CML_CLD", nlon, nlev, nclv, nproma, ngptot, nblocks, tend_cml_cld);
+  load_and_expand_2d(file_id, "TENDENCY_TMP_T", nlon, nlev, nproma, ngptot, nblocks, tend_tmp_t);
+  load_and_expand_2d(file_id, "TENDENCY_TMP_Q", nlon, nlev, nproma, ngptot, nblocks, tend_tmp_q);
+  load_and_expand_2d(file_id, "TENDENCY_TMP_A", nlon, nlev, nproma, ngptot, nblocks, tend_tmp_a);
+  load_and_expand_3d(file_id, "TENDENCY_TMP_CLD", nlon, nlev, nclv, nproma, ngptot, nblocks, tend_tmp_cld);
+  load_and_expand_2d(file_id, "PVFA", nlon, nlev, nproma, ngptot, nblocks, pvfa);
+  load_and_expand_2d(file_id, "PVFL", nlon, nlev, nproma, ngptot, nblocks, pvfl);
+  load_and_expand_2d(file_id, "PVFI", nlon, nlev, nproma, ngptot, nblocks, pvfi);
+  load_and_expand_2d(file_id, "PDYNA", nlon, nlev, nproma, ngptot, nblocks, pdyna);
+  load_and_expand_2d(file_id, "PDYNL", nlon, nlev, nproma, ngptot, nblocks, pdynl);
+  load_and_expand_2d(file_id, "PDYNI", nlon, nlev, nproma, ngptot, nblocks, pdyni);
+  load_and_expand_2d(file_id, "PHRSW", nlon, nlev, nproma, ngptot, nblocks, phrsw);
+  load_and_expand_2d(file_id, "PHRLW", nlon, nlev, nproma, ngptot, nblocks, phrlw);
+  load_and_expand_2d(file_id, "PVERVEL", nlon, nlev, nproma, ngptot, nblocks, pvervel);
+  load_and_expand_2d(file_id, "PAP", nlon, nlev, nproma, ngptot, nblocks, pap);
+  load_and_expand_2d(file_id, "PAPH", nlon, nlev+1, nproma, ngptot, nblocks, paph);
+  load_and_expand_1d(file_id, "PLSM", nlon, nproma, ngptot, nblocks, plsm);
+  load_and_expand_1d_int(file_id, "KTYPE", nlon, nproma, ngptot, nblocks, ktype);
+  load_and_expand_2d(file_id, "PLU", nlon, nlev, nproma, ngptot, nblocks, plu);
+  load_and_expand_2d(file_id, "PLUDE", nlon, nlev, nproma, ngptot, nblocks, plude);
+  load_and_expand_2d(file_id, "PSNDE", nlon, nlev, nproma, ngptot, nblocks, psnde);
+  load_and_expand_2d(file_id, "PMFU", nlon, nlev, nproma, ngptot, nblocks, pmfu);
+  load_and_expand_2d(file_id, "PMFD", nlon, nlev, nproma, ngptot, nblocks, pmfd);
+  load_and_expand_2d(file_id, "PA", nlon, nlev, nproma, ngptot, nblocks, pa);
+  load_and_expand_3d(file_id, "PCLV", nlon, nlev, nclv, nproma, ngptot, nblocks, pclv);
+  load_and_expand_2d(file_id, "PSUPSAT", nlon, nlev, nproma, ngptot, nblocks, psupsat);
+  
+  read_hdf5(file_id, "/PTSPHY", ptsphy);
+  
+  read_hdf5(file_id, "/RG", rg);
+  read_hdf5(file_id, "/RD", rd);
+  read_hdf5(file_id, "/RCPD", rcpd); 
+  read_hdf5(file_id, "/RETV", retv);   
+  read_hdf5(file_id, "/RLVTT", rlvtt);  
+  read_hdf5(file_id, "/RLSTT", rlstt);  
+  read_hdf5(file_id, "/RLMLT", rlmlt);  
+  read_hdf5(file_id, "/RTT", rtt);  
+  read_hdf5(file_id, "/RV", rv);  
+  read_hdf5(file_id, "/R2ES", r2es);  
+  read_hdf5(file_id, "/R3LES", r3les);  
+  read_hdf5(file_id, "/R3IES", r3ies);  
+  read_hdf5(file_id, "/R4LES", r4les);  
+  read_hdf5(file_id, "/R4IES", r4ies);  
+  read_hdf5(file_id, "/R5LES", r5les);  
+  read_hdf5(file_id, "/R5IES", r5ies);  
+  read_hdf5(file_id, "/R5ALVCP", r5alvcp);  
+  read_hdf5(file_id, "/R5ALSCP", r5alscp);  
+  read_hdf5(file_id, "/RALVDCP", ralvdcp);  
+  read_hdf5(file_id, "/RALSDCP", ralsdcp);  
+  read_hdf5(file_id, "/RALFDCP", ralfdcp);  
+  read_hdf5(file_id, "/RTWAT", rtwat);  
+  read_hdf5(file_id, "/RTICE", rtice);  
+  read_hdf5(file_id, "/RTICECU", rticecu);  
+  read_hdf5(file_id, "/RTWAT_RTICE_R", rtwat_rtice_r);  
+  read_hdf5(file_id, "/RTWAT_RTICECU_R", rtwat_rticecu_r);  
+  read_hdf5(file_id, "/RKOOP1", rkoop1);  
+  read_hdf5(file_id, "/RKOOP2", rkoop2);  
+  
+  read_hdf5(file_id, "/YRECLDP_RAMID", &yrecldp->ramid);  
+  read_hdf5(file_id, "/YRECLDP_RCLDIFF", &yrecldp->rcldiff);  
+  read_hdf5(file_id, "/YRECLDP_RCLDIFF_CONVI", &yrecldp->rcldiff_convi);  
+  read_hdf5(file_id, "/YRECLDP_RCLCRIT", &yrecldp->rclcrit);  
+  read_hdf5(file_id, "/YRECLDP_RCLCRIT_SEA", &yrecldp->rclcrit_sea);  
+  read_hdf5(file_id, "/YRECLDP_RCLCRIT_LAND", &yrecldp->rclcrit_land);  
+  read_hdf5(file_id, "/YRECLDP_RKCONV", &yrecldp->rkconv);  
+  read_hdf5(file_id, "/YRECLDP_RPRC1", &yrecldp->rprc1);  
+  read_hdf5(file_id, "/YRECLDP_RPRC2", &yrecldp->rprc2);  
+  read_hdf5(file_id, "/YRECLDP_RCLDMAX", &yrecldp->rcldmax);  
+  read_hdf5(file_id, "/YRECLDP_RPECONS", &yrecldp->rpecons);  
+  read_hdf5(file_id, "/YRECLDP_RVRFACTOR", &yrecldp->rvrfactor);  
+  read_hdf5(file_id, "/YRECLDP_RPRECRHMAX", &yrecldp->rprecrhmax);  
+  read_hdf5(file_id, "/YRECLDP_RTAUMEL", &yrecldp->rtaumel);  
+  read_hdf5(file_id, "/YRECLDP_RAMIN", &yrecldp->ramin);  
+  read_hdf5(file_id, "/YRECLDP_RLMIN", &yrecldp->rlmin);  
+  read_hdf5(file_id, "/YRECLDP_RKOOPTAU", &yrecldp->rkooptau);  
+  read_hdf5(file_id, "/YRECLDP_RCLDTOPP", &yrecldp->rcldtopp);  
+  read_hdf5(file_id, "/YRECLDP_RLCRITSNOW", &yrecldp->rlcritsnow);  
+  read_hdf5(file_id, "/YRECLDP_RSNOWLIN1", &yrecldp->rsnowlin1);  
+  read_hdf5(file_id, "/YRECLDP_RSNOWLIN2", &yrecldp->rsnowlin2);  
+  read_hdf5(file_id, "/YRECLDP_RICEHI1", &yrecldp->ricehi1);  
+  read_hdf5(file_id, "/YRECLDP_RICEHI2", &yrecldp->ricehi2);  
+  read_hdf5(file_id, "/YRECLDP_RICEINIT", &yrecldp->riceinit);  
+  read_hdf5(file_id, "/YRECLDP_RVICE", &yrecldp->rvice);  
+  read_hdf5(file_id, "/YRECLDP_RVRAIN", &yrecldp->rvrain);  
+  read_hdf5(file_id, "/YRECLDP_RVSNOW", &yrecldp->rvsnow);  
+  read_hdf5(file_id, "/YRECLDP_RTHOMO", &yrecldp->rthomo);  
+  read_hdf5(file_id, "/YRECLDP_RCOVPMIN", &yrecldp->rcovpmin);  
+  read_hdf5(file_id, "/YRECLDP_RCCN", &yrecldp->rccn);  
+  read_hdf5(file_id, "/YRECLDP_RNICE", &yrecldp->rnice);  
+  read_hdf5(file_id, "/YRECLDP_RCCNOM", &yrecldp->rccnom);  
+  read_hdf5(file_id, "/YRECLDP_RCCNSS", &yrecldp->rccnss);  
+  read_hdf5(file_id, "/YRECLDP_RCCNSU", &yrecldp->rccnsu);  
+  read_hdf5(file_id, "/YRECLDP_RCLDTOPCF", &yrecldp->rcldtopcf);  
+  read_hdf5(file_id, "/YRECLDP_RDEPLIQREFRATE", &yrecldp->rdepliqrefrate);  
+  read_hdf5(file_id, "/YRECLDP_RDEPLIQREFDEPTH", &yrecldp->rdepliqrefdepth);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KKAac", &yrecldp->rcl_kkaac);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KKBac", &yrecldp->rcl_kkbac);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KKAau", &yrecldp->rcl_kkaau);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KKBauq", &yrecldp->rcl_kkbauq);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KKBaun", &yrecldp->rcl_kkbaun);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KK_cloud_num_sea", &yrecldp->rcl_kk_cloud_num_sea);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KK_cloud_num_land", &yrecldp->rcl_kk_cloud_num_land);  
+  read_hdf5(file_id, "/YRECLDP_RCL_AI", &yrecldp->rcl_ai);  
+  read_hdf5(file_id, "/YRECLDP_RCL_BI", &yrecldp->rcl_bi);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CI", &yrecldp->rcl_ci);  
+  read_hdf5(file_id, "/YRECLDP_RCL_DI", &yrecldp->rcl_di);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X1I", &yrecldp->rcl_x1i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X2I", &yrecldp->rcl_x2i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X3I", &yrecldp->rcl_x3i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X4I", &yrecldp->rcl_x4i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST1I", &yrecldp->rcl_const1i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST2I", &yrecldp->rcl_const2i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST3I", &yrecldp->rcl_const3i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST4I", &yrecldp->rcl_const4i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST5I", &yrecldp->rcl_const5i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST6I", &yrecldp->rcl_const6i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_APB1", &yrecldp->rcl_apb1);  
+  read_hdf5(file_id, "/YRECLDP_RCL_APB2", &yrecldp->rcl_apb2);  
+  read_hdf5(file_id, "/YRECLDP_RCL_APB3", &yrecldp->rcl_apb3);  
+  read_hdf5(file_id, "/YRECLDP_RCL_AS", &yrecldp->rcl_as);  
+  read_hdf5(file_id, "/YRECLDP_RCL_BS", &yrecldp->rcl_bs);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CS", &yrecldp->rcl_cs);  
+  read_hdf5(file_id, "/YRECLDP_RCL_DS", &yrecldp->rcl_ds);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X1S", &yrecldp->rcl_x1s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X2S", &yrecldp->rcl_x2s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X3S", &yrecldp->rcl_x3s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X4S", &yrecldp->rcl_x4s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST1S", &yrecldp->rcl_const1s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST2S", &yrecldp->rcl_const2s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST3S", &yrecldp->rcl_const3s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST4S", &yrecldp->rcl_const4s);   
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST5S", &yrecldp->rcl_const5s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST6S", &yrecldp->rcl_const6s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST7S", &yrecldp->rcl_const7s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST8S", &yrecldp->rcl_const8s);   
+  read_hdf5(file_id, "/YRECLDP_RDENSWAT", &yrecldp->rdenswat);  
+  read_hdf5(file_id, "/YRECLDP_RDENSREF", &yrecldp->rdensref);  
+  read_hdf5(file_id, "/YRECLDP_RCL_AR", &yrecldp->rcl_ar);  
+  read_hdf5(file_id, "/YRECLDP_RCL_BR", &yrecldp->rcl_br);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CR", &yrecldp->rcl_cr);  
+  read_hdf5(file_id, "/YRECLDP_RCL_DR", &yrecldp->rcl_dr);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X1R", &yrecldp->rcl_x1r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X2R", &yrecldp->rcl_x2r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X4R", &yrecldp->rcl_x4r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KA273", &yrecldp->rcl_ka273);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CDENOM1", &yrecldp->rcl_cdenom1);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CDENOM2", &yrecldp->rcl_cdenom2);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CDENOM3", &yrecldp->rcl_cdenom3);  
+  read_hdf5(file_id, "/YRECLDP_RCL_SCHMIDT", &yrecldp->rcl_schmidt);  
+  read_hdf5(file_id, "/YRECLDP_RCL_DYNVISC", &yrecldp->rcl_dynvisc);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST1R", &yrecldp->rcl_const1r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST2R", &yrecldp->rcl_const2r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST3R", &yrecldp->rcl_const3r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST4R", &yrecldp->rcl_const4r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_FAC1", &yrecldp->rcl_fac1);  
+  read_hdf5(file_id, "/YRECLDP_RCL_FAC2", &yrecldp->rcl_fac2);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST5R", &yrecldp->rcl_const5r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST6R", &yrecldp->rcl_const6r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_FZRAB", &yrecldp->rcl_fzrab);  
+  read_hdf5(file_id, "/YRECLDP_RCL_FZRBB", &yrecldp->rcl_fzrbb);
+  read_hdf5_int(file_id, "/YRECLDP_LCLDEXTRA", &yrecldp->lcldextra); // Bool
+  read_hdf5_int(file_id, "/YRECLDP_LCLDBUDGET", &yrecldp->lcldbudget); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_NSSOPT", &yrecldp->nssopt);   
+  read_hdf5_int(file_id, "/YRECLDP_NCLDTOP", &yrecldp->ncldtop);  
+  read_hdf5_int(file_id, "/YRECLDP_NAECLBC", &yrecldp->naeclbc);  
+  read_hdf5_int(file_id, "/YRECLDP_NAECLDU", &yrecldp->naecldu);  
+  read_hdf5_int(file_id, "/YRECLDP_NAECLOM", &yrecldp->naeclom);  
+  read_hdf5_int(file_id, "/YRECLDP_NAECLSS", &yrecldp->naeclss);  
+  read_hdf5_int(file_id, "/YRECLDP_NAECLSU", &yrecldp->naeclsu);  
+  read_hdf5_int(file_id, "/YRECLDP_NCLDDIAG", &yrecldp->nclddiag);  
+  read_hdf5_int(file_id, "/YRECLDP_NAERCLD", &yrecldp->naercld);  
+  read_hdf5_int(file_id, "/YRECLDP_LAERLIQAUTOLSP", &yrecldp->laerliqautolsp); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_LAERLIQAUTOCP", &yrecldp->laerliqautocp); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_LAERLIQAUTOCPB", &yrecldp->laerliqautocpb); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_LAERLIQCOLL", &yrecldp->laerliqcoll); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_LAERICESED", &yrecldp->laericesed); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_LAERICEAUTO", &yrecldp->laericeauto); // Bool 
+  read_hdf5(file_id, "/YRECLDP_NSHAPEP", &yrecldp->nshapep);  
+  read_hdf5(file_id, "/YRECLDP_NSHAPEQ", &yrecldp->nshapeq);  
+  read_hdf5_int(file_id, "/YRECLDP_NBETA", &yrecldp->nbeta);  
+  
+  status = H5Fclose(file_id);
+
+#endif
+
 }
+
+
 
 /* Read reference result into memory */
 void load_reference(const int nlon, const int nlev, const int nclv, const int ngptot, const int nproma,
@@ -364,12 +656,14 @@ void load_reference(const int nlon, const int nlev, const int nclv, const int ng
 		    double *pfsqltur, double *pfsqitur, double *pfplsl, double *pfplsn, double *pfhpsl, double *pfhpsn,
 		    double *tend_loc_a, double *tend_loc_q, double *tend_loc_t, double *tend_loc_cld)
 {
+
+  int nblocks = (ngptot / nproma) + min(ngptot % nproma, 1);
+
+#ifdef HAVE_SERIALBOX
   serialboxSerializer_t* serializer = serialboxSerializerCreate(Read, "./data", "reference", "Binary");
   serialboxMetainfo_t* metainfo = serialboxSerializerGetGlobalMetainfo(serializer);
   serialboxSavepoint_t** savepoints = serialboxSerializerGetSavepointVector(serializer);
   serialboxSavepoint_t* savepoint = savepoints[0];
-
-  int nblocks = (ngptot / nproma) + min(ngptot % nproma, 1);
 
   load_and_expand_2d(serializer, savepoint, "PLUDE", nlon, nlev, nproma, ngptot, nblocks, plude);
   load_and_expand_2d(serializer, savepoint, "PCOVPTOT", nlon, nlev, nproma, ngptot, nblocks, pcovptot);
@@ -395,4 +689,37 @@ void load_reference(const int nlon, const int nlev, const int nclv, const int ng
 
   serialboxSerializerDestroySavepointVector(savepoints, 1);
   serialboxSerializerDestroy(serializer);
+#endif
+
+#ifdef HAVE_HDF5
+
+  hid_t file_id, dataset_id;
+  herr_t  status;
+  file_id = H5Fopen(REFERENCE_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+
+  load_and_expand_2d(file_id, "PLUDE", nlon, nlev, nproma, ngptot, nblocks, plude);
+  load_and_expand_2d(file_id, "PCOVPTOT", nlon, nlev, nproma, ngptot, nblocks, pcovptot);
+  load_and_expand_1d(file_id, "PRAINFRAC_TOPRFZ", nlon, nproma, ngptot, nblocks, prainfrac_toprfz);
+  load_and_expand_2d(file_id, "PFSQLF", nlon, nlev+1, nproma, ngptot, nblocks, pfsqlf);
+  load_and_expand_2d(file_id, "PFSQIF", nlon, nlev+1, nproma, ngptot, nblocks, pfsqif);
+  load_and_expand_2d(file_id, "PFCQLNG", nlon, nlev+1, nproma, ngptot, nblocks, pfcqlng);
+  load_and_expand_2d(file_id, "PFCQNNG", nlon, nlev+1, nproma, ngptot, nblocks, pfcqnng);
+  load_and_expand_2d(file_id, "PFSQRF", nlon, nlev+1, nproma, ngptot, nblocks, pfsqrf);
+  load_and_expand_2d(file_id, "PFSQSF", nlon, nlev+1, nproma, ngptot, nblocks, pfsqsf);
+  load_and_expand_2d(file_id, "PFCQRNG", nlon, nlev+1, nproma, ngptot, nblocks, pfcqrng);
+  load_and_expand_2d(file_id, "PFCQSNG", nlon, nlev+1, nproma, ngptot, nblocks, pfcqsng);
+  load_and_expand_2d(file_id, "PFSQLTUR", nlon, nlev+1, nproma, ngptot, nblocks, pfsqltur);
+  load_and_expand_2d(file_id, "PFSQITUR", nlon, nlev+1, nproma, ngptot, nblocks, pfsqitur);
+  load_and_expand_2d(file_id, "PFPLSL", nlon, nlev+1, nproma, ngptot, nblocks, pfplsl);
+  load_and_expand_2d(file_id, "PFPLSN", nlon, nlev+1, nproma, ngptot, nblocks, pfplsn);
+  load_and_expand_2d(file_id, "PFHPSL", nlon, nlev+1, nproma, ngptot, nblocks, pfhpsl);
+  load_and_expand_2d(file_id, "PFHPSN", nlon, nlev+1, nproma, ngptot, nblocks, pfhpsn);
+  load_and_expand_2d(file_id, "TENDENCY_LOC_T", nlon, nlev, nproma, ngptot, nblocks, tend_loc_t);
+  load_and_expand_2d(file_id, "TENDENCY_LOC_Q", nlon, nlev, nproma, ngptot, nblocks, tend_loc_q);
+  load_and_expand_2d(file_id, "TENDENCY_LOC_A", nlon, nlev, nproma, ngptot, nblocks, tend_loc_a);
+  load_and_expand_3d(file_id, "TENDENCY_LOC_CLD", nlon, nlev, nclv, nproma, ngptot, nblocks, tend_loc_cld);
+
+  status = H5Fclose(file_id);
+#endif
+
 }

--- a/src/cloudsc_sycl/CMakeLists.txt
+++ b/src/cloudsc_sycl/CMakeLists.txt
@@ -9,7 +9,7 @@
 # Define this dwarf variant as an ECBuild feature
 ecbuild_add_option( FEATURE CLOUDSC_SYCL
     DESCRIPTION "Build the SYCL version CLOUDSC using Serialbox" DEFAULT ON
-    CONDITION Serialbox_FOUND AND HAVE_SYCL
+    CONDITION (Serialbox_FOUND OR HDF5_FOUND) AND HAVE_SYCL
 )
 
 if( HAVE_CLOUDSC_SYCL )
@@ -32,8 +32,11 @@ if( HAVE_CLOUDSC_SYCL )
             $<INSTALL_INTERFACE:include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cloudsc>
         PUBLIC_LIBS
-            Serialbox::Serialbox_C
-    	    $<${HAVE_OMP}:OpenMP::OpenMP_C>
+            $<${HAVE_HDF5}:hdf5::hdf5>
+            $<${HAVE_SERIALBOX}:Serialbox::Serialbox_C>
+            $<${HAVE_OMP}:OpenMP::OpenMP_C>
+        DEFINITIONS
+            ${CLOUDSC_DEFINITIONS}
     )
 
     add_sycl_to_target(
@@ -77,8 +80,11 @@ if( HAVE_CLOUDSC_SYCL )
             $<INSTALL_INTERFACE:include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cloudsc>
         PUBLIC_LIBS
-	    Serialbox::Serialbox_C
+            $<${HAVE_HDF5}:hdf5::hdf5>
+            $<${HAVE_SERIALBOX}:Serialbox::Serialbox_C>
             $<${HAVE_OMP}:OpenMP::OpenMP_C>
+        DEFINITIONS
+            ${CLOUDSC_DEFINITIONS}
     )
 
     add_sycl_to_target(
@@ -122,8 +128,11 @@ if( HAVE_CLOUDSC_SYCL )
             $<INSTALL_INTERFACE:include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cloudsc>
         PUBLIC_LIBS
-	    Serialbox::Serialbox_C
+            $<${HAVE_HDF5}:hdf5::hdf5>
+            $<${HAVE_SERIALBOX}:Serialbox::Serialbox_C>
             $<${HAVE_OMP}:OpenMP::OpenMP_C>
+        DEFINITIONS
+            ${CLOUDSC_DEFINITIONS}
     )
 
     add_sycl_to_target(
@@ -147,9 +156,18 @@ if( HAVE_CLOUDSC_SYCL )
         OMP 1
     )
 
-    # Create symlink for the input data
-    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../data ${CMAKE_CURRENT_BINARY_DIR}/../../../data )
+ # Create symlink for the input data
+ if( HAVE_SERIALBOX )
+   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+       ${CMAKE_CURRENT_SOURCE_DIR}/../../data ${CMAKE_CURRENT_BINARY_DIR}/../../../data )
+ endif()
+
+ if( HAVE_HDF5 )
+   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+       ${CMAKE_CURRENT_SOURCE_DIR}/../../config-files/input.h5 ${CMAKE_CURRENT_BINARY_DIR}/../../../input.h5 )
+   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+       ${CMAKE_CURRENT_SOURCE_DIR}/../../config-files/reference.h5 ${CMAKE_CURRENT_BINARY_DIR}/../../../reference.h5 )
+ endif()
 
 else()
 	ecbuild_info( "Serialbox not found, disabling SYCL version" )

--- a/src/cloudsc_sycl/cloudsc/cloudsc_validate.cpp
+++ b/src/cloudsc_sycl/cloudsc/cloudsc_validate.cpp
@@ -51,8 +51,6 @@ void validate_1d(const char *name, double * v_ref, double * v_field, int nlon, i
   /* Computes and prints errors in the "L2 norm sense" */
   int b, bsize, jk;
   double zminval, zmaxval, zdiff, zmaxerr, zerrsum, zsum, zrelerr, zavgpgp;
-  //double (*field)[nlon] = (double (*)[nlon]) v_field;
-  //double (*reference)[nlon] = (double (*)[nlon]) v_ref;
 
   zminval = +std::numeric_limits<double>::max();
   zmaxval = -std::numeric_limits<double>::max();
@@ -60,8 +58,8 @@ void validate_1d(const char *name, double * v_ref, double * v_field, int nlon, i
   zerrsum = 0.0;
   zsum = 0.0;
 
-//  #pragma omp parallel for default(shared) private(b, bsize, jk)		\
-//    reduction(min:zminval) reduction(max:zmaxval,zmaxerr) reduction(+:zerrsum,zsum)
+#pragma omp parallel for default(shared) private(b, bsize, jk)		\
+  reduction(min:zminval) reduction(max:zmaxval,zmaxerr) reduction(+:zerrsum,zsum)
   for (b = 0; b < nblocks; b++) {
     bsize = min(nlon, ngptot - b*nlon);  // field block size
     for (jk = 0; jk < bsize; jk++) {
@@ -85,8 +83,6 @@ void validate_2d(const char *name, double *v_ref, double *v_field, int nlon, int
   /* Computes and prints errors in the "L2 norm sense" */
   int b, bsize, jl, jk;
   double zminval, zmaxval, zdiff, zmaxerr, zerrsum, zsum, zrelerr, zavgpgp;
-//  double (*field)[nlev][nlon] = (double (*)[nlev][nlon]) v_field;
-//  double (*reference)[nlev][nlon] = (double (*)[nlev][nlon]) v_ref;
 
   zminval = +std::numeric_limits<double>::max();
   zmaxval = -std::numeric_limits<double>::max();
@@ -94,9 +90,8 @@ void validate_2d(const char *name, double *v_ref, double *v_field, int nlon, int
   zerrsum = 0.0;
   zsum = 0.0;
 
-//  #pragma omp parallel for default(shared) private(b, bsize, jl, jk) \
-//    reduction(min:zminval) reduction(max:zmaxval,zmaxerr) reduction(+:zerrsum,zsum)
-
+#pragma omp parallel for default(shared) private(b, bsize, jl, jk) \
+  reduction(min:zminval) reduction(max:zmaxval,zmaxerr) reduction(+:zerrsum,zsum)
   for (b = 0; b < nblocks; b++) {
     bsize = min(nlon, ngptot - b*nlon);  // field block size
     for (jl = 0; jl < nlev; jl++) {
@@ -124,8 +119,6 @@ void validate_3d(const char *name, double *v_ref, double *v_field, int nlon,
   /* Computes and prints errors in the "L2 norm sense" */
   int b, bsize, jl, jk, jm;
   double zminval, zmaxval, zdiff, zmaxerr, zerrsum, zsum, zrelerr, zavgpgp;
-//  double (*field)[nclv][nlev][nlon] = (double (*)[nclv][nlev][nlon]) v_field;
-//  double (*reference)[nclv][nlev][nlon] = (double (*)[nclv][nlev][nlon]) v_ref;
 
   zminval = +std::numeric_limits<double>::max();
   zmaxval = -std::numeric_limits<double>::max();
@@ -133,8 +126,8 @@ void validate_3d(const char *name, double *v_ref, double *v_field, int nlon,
   zerrsum = 0.0;
   zsum = 0.0;
 
-//  #pragma omp parallel for default(shared) private(b, bsize, jl, jk, jm) \
-//    reduction(min:zminval) reduction(max:zmaxval,zmaxerr) reduction(+:zerrsum,zsum)
+#pragma omp parallel for default(shared) private(b, bsize, jl, jk, jm) \
+  reduction(min:zminval) reduction(max:zmaxval,zmaxerr) reduction(+:zerrsum,zsum)
   for (b = 0; b < nblocks; b++) {
     bsize = min(nlon, ngptot - b*nlon);  // field block size
     for (jm = 0; jm < nclv; jm++) {

--- a/src/cloudsc_sycl/cloudsc/load_state.cpp
+++ b/src/cloudsc_sycl/cloudsc/load_state.cpp
@@ -9,17 +9,42 @@
  */
 
 #include "load_state.h"
-#include <iostream>
 
 #include <math.h>
+#ifdef HAVE_SERIALBOX
 #include "serialbox-c/Serialbox.h"
+#endif
+#ifdef HAVE_HDF5
+#include "hdf5.h"
+#define INPUT_FILE "input.h5"
+#define REFERENCE_FILE "reference.h5"
+#endif
 
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 #define max(a, b) (((a) > (b)) ? (a) : (b))
 
+#ifdef HAVE_HDF5
+void read_hdf5_int(hid_t file_id, const char *name, int *field) {
+  hid_t dataset_id;
+  herr_t  status;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  status = H5Dread(dataset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, field);
+  status = H5Dclose(dataset_id);
+}
+
+void read_hdf5(hid_t file_id, const char *name, double *field) {
+  hid_t dataset_id;
+  herr_t  status;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, field);
+  status = H5Dclose(dataset_id);
+}
+#endif
+
 /* Query sizes and dimensions of state arrays */
 void query_state(int *klon, int *klev)
 {
+#ifdef HAVE_SERIALBOX
   serialboxSerializer_t* serializer = serialboxSerializerCreate(Read, "./data", "input", "Binary");
   serialboxMetainfo_t* globalMetainfo = serialboxSerializerGetGlobalMetainfo(serializer);
 
@@ -28,6 +53,17 @@ void query_state(int *klon, int *klev)
 
   serialboxMetainfoDestroy(globalMetainfo);
   serialboxSerializerDestroy(serializer);
+#endif
+#ifdef HAVE_HDF5
+  hid_t file_id, dataset_id;
+  herr_t  status;
+  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+  
+  read_hdf5_int(file_id, "/KLEV", klev);
+  read_hdf5_int(file_id, "/KLON", klon);
+  
+  status = H5Fclose(file_id);
+#endif
 }
 
 void expand_1d(double *buffer, double *field_in, int nlon, int nproma, int ngptot, int nblocks)
@@ -94,7 +130,7 @@ void expand_3d(double *buffer_in, double *field_in, int nlon, int nlev, int nclv
   }
 }
 
-
+#ifdef HAVE_SERIALBOX
 void load_and_expand_1d(serialboxSerializer_t *serializer, serialboxSavepoint_t* savepoint,
     const char *name, int nlon, int nproma, int ngptot, int nblocks, double *field)
 {
@@ -134,31 +170,82 @@ void load_and_expand_3d(serialboxSerializer_t *serializer, serialboxSavepoint_t*
   serialboxSerializerRead(serializer, name, savepoint, buffer, strides, 3);
   expand_3d((double *)buffer, field, nlon, nlev, nclv, nproma, ngptot, nblocks);
 }
+#endif
 
+#if HAVE_HDF5
+void load_and_expand_1d(hid_t file_id, const char *name, int nlon, int nproma, int ngptot, int nblocks, double *field)
+{
+  double buffer[nlon];
+  int strides[1] = {1};
+  hid_t dataset_id;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  herr_t  status;
+  status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
+  status = H5Dclose(dataset_id);
+  expand_1d((double *)buffer, field, nlon, nproma, ngptot, nblocks);
+}
+
+void load_and_expand_1d_int(hid_t file_id, const char *name, int nlon, int nproma, int ngptot, int nblocks, int *field)
+{
+  int buffer[nlon];
+  int strides[1] = {1};
+  hid_t dataset_id;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  herr_t  status;
+  status = H5Dread(dataset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
+  status = H5Dclose(dataset_id);
+  expand_1d_int((int *)buffer, field, nlon, nproma, ngptot, nblocks);
+}
+
+void load_and_expand_2d(hid_t file_id, const char *name, int nlon, int nlev, int nproma, int ngptot, int nblocks, double *field)
+{
+  double buffer[nlev][nlon];
+  int strides[2] = {1, nlon};
+  hid_t dataset_id;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  herr_t  status;
+  status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
+  status = H5Dclose(dataset_id);
+  expand_2d((double *)buffer, field, nlon, nlev, nproma, ngptot, nblocks);
+}
+
+void load_and_expand_3d(hid_t file_id, const char *name, int nlon, int nlev, int nclv, int nproma, int ngptot, int nblocks, double *field)
+{
+  double buffer[nclv][nlev][nlon];
+  int strides[3] = {1, nlon, nlev*nlon};
+  hid_t dataset_id;
+  dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
+  herr_t  status;
+  status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
+  status = H5Dclose(dataset_id);
+  expand_3d((double *)buffer, field, nlon, nlev, nclv, nproma, ngptot, nblocks);
+}
+#endif
 
 /* Read input state into memory */
-void load_state(const int nlon, const int nlev, const int nclv, const int ngptot, const int nproma, 
-    double* ptsphy, double* plcrit_aer, double* picrit_aer,
-    double* pre_ice, double* pccn, double* pnice, double* pt, double* pq, 
-    double* tend_cml_t, double* tend_cml_q, double* tend_cml_a, double* tend_cml_cld,
-    double* tend_tmp_t, double* tend_tmp_q, double* tend_tmp_a, double* tend_tmp_cld,
-    double* pvfa, double* pvfl, double* pvfi, double* pdyna, double* pdynl, double* pdyni, 
-    double* phrsw, double* phrlw, double* pvervel, double* pap, double* paph, double* plsm,
-    int* ktype, double* plu, double* plude, double* psnde, double* pmfu,
-    double* pmfd, double* pa, double* pclv, double* psupsat, struct TECLDP* yrecldp,
-    double* rg, double* rd, double* rcpd, double* retv, double* rlvtt, double* rlstt, 
-    double* rlmlt, double* rtt, double* rv, double* r2es, double* r3les, double* r3ies,
-    double* r4les, double* r4ies, double* r5les, double* r5ies, double* r5alvcp, double* r5alscp,
-    double* ralvdcp, double* ralsdcp, double* ralfdcp, double* rtwat, 
-    double* rtice, double* rticecu, double* rtwat_rtice_r, double *rtwat_rticecu_r,
-    double* rkoop1, double* rkoop2 )
-{
+void load_state(const int nlon, const int nlev, const int nclv, const int ngptot, const int nproma,
+                double* ptsphy, double* plcrit_aer, double* picrit_aer,
+                double* pre_ice, double* pccn, double* pnice, double* pt, double* pq,
+                double* tend_cml_t, double* tend_cml_q, double* tend_cml_a, double* tend_cml_cld,
+                double* tend_tmp_t, double* tend_tmp_q, double* tend_tmp_a, double* tend_tmp_cld,
+                double* pvfa, double* pvfl, double* pvfi, double* pdyna, double* pdynl, double* pdyni,
+                double* phrsw, double* phrlw, double* pvervel, double* pap, double* paph, double* plsm,
+                int* ktype, double* plu, double* plude, double* psnde, double* pmfu,
+                double* pmfd, double* pa, double* pclv, double* psupsat, struct TECLDP* yrecldp,
+                double* rg, double* rd, double* rcpd, double* retv, double* rlvtt, double* rlstt,
+                double* rlmlt, double* rtt, double* rv, double* r2es, double* r3les, double* r3ies,
+                double* r4les, double* r4ies, double* r5les, double* r5ies, double* r5alvcp, double* r5alscp,
+                double* ralvdcp, double* ralsdcp, double* ralfdcp, double* rtwat,
+                double* rtice, double* rticecu, double* rtwat_rtice_r, double *rtwat_rticecu_r,
+                double* rkoop1, double* rkoop2) {
+
+  int nblocks = (ngptot / nproma) + min(ngptot % nproma, 1);
+
+#ifdef HAVE_SERIALBOX
   serialboxSerializer_t* serializer = serialboxSerializerCreate(Read, "./data", "input", "Binary");
   serialboxMetainfo_t* metainfo = serialboxSerializerGetGlobalMetainfo(serializer);
   serialboxSavepoint_t** savepoints = serialboxSerializerGetSavepointVector(serializer);
   serialboxSavepoint_t* savepoint = savepoints[0];
-
-  int nblocks = (ngptot / nproma) + min(ngptot % nproma, 1);
 
   load_and_expand_2d(serializer, savepoint, "PLCRIT_AER", nlon, nlev, nproma, ngptot, nblocks, plcrit_aer);
   load_and_expand_2d(serializer, savepoint, "PICRIT_AER", nlon, nlev, nproma, ngptot, nblocks, picrit_aer);
@@ -355,7 +442,212 @@ void load_state(const int nlon, const int nlev, const int nclv, const int ngptot
 
   serialboxSerializerDestroySavepointVector(savepoints, 1);
   serialboxSerializerDestroy(serializer);
+#endif
+
+#ifdef HAVE_HDF5
+
+  hid_t file_id, dataset_id;
+  herr_t  status;
+  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+
+  load_and_expand_2d(file_id, "PLCRIT_AER", nlon, nlev, nproma, ngptot, nblocks, plcrit_aer);
+  load_and_expand_2d(file_id, "PICRIT_AER", nlon, nlev, nproma, ngptot, nblocks, picrit_aer);
+  load_and_expand_2d(file_id, "PRE_ICE", nlon, nlev, nproma, ngptot, nblocks, pre_ice);
+  load_and_expand_2d(file_id, "PCCN", nlon, nlev, nproma, ngptot, nblocks, pccn);
+  load_and_expand_2d(file_id, "PNICE", nlon, nlev, nproma, ngptot, nblocks, pnice);
+  load_and_expand_2d(file_id, "PT", nlon, nlev, nproma, ngptot, nblocks, pt);
+  load_and_expand_2d(file_id, "PQ", nlon, nlev, nproma, ngptot, nblocks, pq);
+  load_and_expand_2d(file_id, "TENDENCY_CML_T", nlon, nlev, nproma, ngptot, nblocks, tend_cml_t);
+  load_and_expand_2d(file_id, "TENDENCY_CML_Q", nlon, nlev, nproma, ngptot, nblocks, tend_cml_q);
+  load_and_expand_2d(file_id, "TENDENCY_CML_A", nlon, nlev, nproma, ngptot, nblocks, tend_cml_a);
+  load_and_expand_3d(file_id, "TENDENCY_CML_CLD", nlon, nlev, nclv, nproma, ngptot, nblocks, tend_cml_cld);
+  load_and_expand_2d(file_id, "TENDENCY_TMP_T", nlon, nlev, nproma, ngptot, nblocks, tend_tmp_t);
+  load_and_expand_2d(file_id, "TENDENCY_TMP_Q", nlon, nlev, nproma, ngptot, nblocks, tend_tmp_q);
+  load_and_expand_2d(file_id, "TENDENCY_TMP_A", nlon, nlev, nproma, ngptot, nblocks, tend_tmp_a);
+  load_and_expand_3d(file_id, "TENDENCY_TMP_CLD", nlon, nlev, nclv, nproma, ngptot, nblocks, tend_tmp_cld);
+  load_and_expand_2d(file_id, "PVFA", nlon, nlev, nproma, ngptot, nblocks, pvfa);
+  load_and_expand_2d(file_id, "PVFL", nlon, nlev, nproma, ngptot, nblocks, pvfl);
+  load_and_expand_2d(file_id, "PVFI", nlon, nlev, nproma, ngptot, nblocks, pvfi);
+  load_and_expand_2d(file_id, "PDYNA", nlon, nlev, nproma, ngptot, nblocks, pdyna);
+  load_and_expand_2d(file_id, "PDYNL", nlon, nlev, nproma, ngptot, nblocks, pdynl);
+  load_and_expand_2d(file_id, "PDYNI", nlon, nlev, nproma, ngptot, nblocks, pdyni);
+  load_and_expand_2d(file_id, "PHRSW", nlon, nlev, nproma, ngptot, nblocks, phrsw);
+  load_and_expand_2d(file_id, "PHRLW", nlon, nlev, nproma, ngptot, nblocks, phrlw);
+  load_and_expand_2d(file_id, "PVERVEL", nlon, nlev, nproma, ngptot, nblocks, pvervel);
+  load_and_expand_2d(file_id, "PAP", nlon, nlev, nproma, ngptot, nblocks, pap);
+  load_and_expand_2d(file_id, "PAPH", nlon, nlev+1, nproma, ngptot, nblocks, paph);
+  load_and_expand_1d(file_id, "PLSM", nlon, nproma, ngptot, nblocks, plsm);
+  load_and_expand_1d_int(file_id, "KTYPE", nlon, nproma, ngptot, nblocks, ktype);
+  load_and_expand_2d(file_id, "PLU", nlon, nlev, nproma, ngptot, nblocks, plu);
+  load_and_expand_2d(file_id, "PLUDE", nlon, nlev, nproma, ngptot, nblocks, plude);
+  load_and_expand_2d(file_id, "PSNDE", nlon, nlev, nproma, ngptot, nblocks, psnde);
+  load_and_expand_2d(file_id, "PMFU", nlon, nlev, nproma, ngptot, nblocks, pmfu);
+  load_and_expand_2d(file_id, "PMFD", nlon, nlev, nproma, ngptot, nblocks, pmfd);
+  load_and_expand_2d(file_id, "PA", nlon, nlev, nproma, ngptot, nblocks, pa);
+  load_and_expand_3d(file_id, "PCLV", nlon, nlev, nclv, nproma, ngptot, nblocks, pclv);
+  load_and_expand_2d(file_id, "PSUPSAT", nlon, nlev, nproma, ngptot, nblocks, psupsat);
+  
+  read_hdf5(file_id, "/PTSPHY", ptsphy);
+  
+  read_hdf5(file_id, "/RG", rg);
+  read_hdf5(file_id, "/RD", rd);
+  read_hdf5(file_id, "/RCPD", rcpd); 
+  read_hdf5(file_id, "/RETV", retv);   
+  read_hdf5(file_id, "/RLVTT", rlvtt);  
+  read_hdf5(file_id, "/RLSTT", rlstt);  
+  read_hdf5(file_id, "/RLMLT", rlmlt);  
+  read_hdf5(file_id, "/RTT", rtt);  
+  read_hdf5(file_id, "/RV", rv);  
+  read_hdf5(file_id, "/R2ES", r2es);  
+  read_hdf5(file_id, "/R3LES", r3les);  
+  read_hdf5(file_id, "/R3IES", r3ies);  
+  read_hdf5(file_id, "/R4LES", r4les);  
+  read_hdf5(file_id, "/R4IES", r4ies);  
+  read_hdf5(file_id, "/R5LES", r5les);  
+  read_hdf5(file_id, "/R5IES", r5ies);  
+  read_hdf5(file_id, "/R5ALVCP", r5alvcp);  
+  read_hdf5(file_id, "/R5ALSCP", r5alscp);  
+  read_hdf5(file_id, "/RALVDCP", ralvdcp);  
+  read_hdf5(file_id, "/RALSDCP", ralsdcp);  
+  read_hdf5(file_id, "/RALFDCP", ralfdcp);  
+  read_hdf5(file_id, "/RTWAT", rtwat);  
+  read_hdf5(file_id, "/RTICE", rtice);  
+  read_hdf5(file_id, "/RTICECU", rticecu);  
+  read_hdf5(file_id, "/RTWAT_RTICE_R", rtwat_rtice_r);  
+  read_hdf5(file_id, "/RTWAT_RTICECU_R", rtwat_rticecu_r);  
+  read_hdf5(file_id, "/RKOOP1", rkoop1);  
+  read_hdf5(file_id, "/RKOOP2", rkoop2);  
+  
+  read_hdf5(file_id, "/YRECLDP_RAMID", &yrecldp->ramid);  
+  read_hdf5(file_id, "/YRECLDP_RCLDIFF", &yrecldp->rcldiff);  
+  read_hdf5(file_id, "/YRECLDP_RCLDIFF_CONVI", &yrecldp->rcldiff_convi);  
+  read_hdf5(file_id, "/YRECLDP_RCLCRIT", &yrecldp->rclcrit);  
+  read_hdf5(file_id, "/YRECLDP_RCLCRIT_SEA", &yrecldp->rclcrit_sea);  
+  read_hdf5(file_id, "/YRECLDP_RCLCRIT_LAND", &yrecldp->rclcrit_land);  
+  read_hdf5(file_id, "/YRECLDP_RKCONV", &yrecldp->rkconv);  
+  read_hdf5(file_id, "/YRECLDP_RPRC1", &yrecldp->rprc1);  
+  read_hdf5(file_id, "/YRECLDP_RPRC2", &yrecldp->rprc2);  
+  read_hdf5(file_id, "/YRECLDP_RCLDMAX", &yrecldp->rcldmax);  
+  read_hdf5(file_id, "/YRECLDP_RPECONS", &yrecldp->rpecons);  
+  read_hdf5(file_id, "/YRECLDP_RVRFACTOR", &yrecldp->rvrfactor);  
+  read_hdf5(file_id, "/YRECLDP_RPRECRHMAX", &yrecldp->rprecrhmax);  
+  read_hdf5(file_id, "/YRECLDP_RTAUMEL", &yrecldp->rtaumel);  
+  read_hdf5(file_id, "/YRECLDP_RAMIN", &yrecldp->ramin);  
+  read_hdf5(file_id, "/YRECLDP_RLMIN", &yrecldp->rlmin);  
+  read_hdf5(file_id, "/YRECLDP_RKOOPTAU", &yrecldp->rkooptau);  
+  read_hdf5(file_id, "/YRECLDP_RCLDTOPP", &yrecldp->rcldtopp);  
+  read_hdf5(file_id, "/YRECLDP_RLCRITSNOW", &yrecldp->rlcritsnow);  
+  read_hdf5(file_id, "/YRECLDP_RSNOWLIN1", &yrecldp->rsnowlin1);  
+  read_hdf5(file_id, "/YRECLDP_RSNOWLIN2", &yrecldp->rsnowlin2);  
+  read_hdf5(file_id, "/YRECLDP_RICEHI1", &yrecldp->ricehi1);  
+  read_hdf5(file_id, "/YRECLDP_RICEHI2", &yrecldp->ricehi2);  
+  read_hdf5(file_id, "/YRECLDP_RICEINIT", &yrecldp->riceinit);  
+  read_hdf5(file_id, "/YRECLDP_RVICE", &yrecldp->rvice);  
+  read_hdf5(file_id, "/YRECLDP_RVRAIN", &yrecldp->rvrain);  
+  read_hdf5(file_id, "/YRECLDP_RVSNOW", &yrecldp->rvsnow);  
+  read_hdf5(file_id, "/YRECLDP_RTHOMO", &yrecldp->rthomo);  
+  read_hdf5(file_id, "/YRECLDP_RCOVPMIN", &yrecldp->rcovpmin);  
+  read_hdf5(file_id, "/YRECLDP_RCCN", &yrecldp->rccn);  
+  read_hdf5(file_id, "/YRECLDP_RNICE", &yrecldp->rnice);  
+  read_hdf5(file_id, "/YRECLDP_RCCNOM", &yrecldp->rccnom);  
+  read_hdf5(file_id, "/YRECLDP_RCCNSS", &yrecldp->rccnss);  
+  read_hdf5(file_id, "/YRECLDP_RCCNSU", &yrecldp->rccnsu);  
+  read_hdf5(file_id, "/YRECLDP_RCLDTOPCF", &yrecldp->rcldtopcf);  
+  read_hdf5(file_id, "/YRECLDP_RDEPLIQREFRATE", &yrecldp->rdepliqrefrate);  
+  read_hdf5(file_id, "/YRECLDP_RDEPLIQREFDEPTH", &yrecldp->rdepliqrefdepth);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KKAac", &yrecldp->rcl_kkaac);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KKBac", &yrecldp->rcl_kkbac);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KKAau", &yrecldp->rcl_kkaau);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KKBauq", &yrecldp->rcl_kkbauq);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KKBaun", &yrecldp->rcl_kkbaun);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KK_cloud_num_sea", &yrecldp->rcl_kk_cloud_num_sea);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KK_cloud_num_land", &yrecldp->rcl_kk_cloud_num_land);  
+  read_hdf5(file_id, "/YRECLDP_RCL_AI", &yrecldp->rcl_ai);  
+  read_hdf5(file_id, "/YRECLDP_RCL_BI", &yrecldp->rcl_bi);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CI", &yrecldp->rcl_ci);  
+  read_hdf5(file_id, "/YRECLDP_RCL_DI", &yrecldp->rcl_di);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X1I", &yrecldp->rcl_x1i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X2I", &yrecldp->rcl_x2i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X3I", &yrecldp->rcl_x3i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X4I", &yrecldp->rcl_x4i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST1I", &yrecldp->rcl_const1i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST2I", &yrecldp->rcl_const2i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST3I", &yrecldp->rcl_const3i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST4I", &yrecldp->rcl_const4i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST5I", &yrecldp->rcl_const5i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST6I", &yrecldp->rcl_const6i);  
+  read_hdf5(file_id, "/YRECLDP_RCL_APB1", &yrecldp->rcl_apb1);  
+  read_hdf5(file_id, "/YRECLDP_RCL_APB2", &yrecldp->rcl_apb2);  
+  read_hdf5(file_id, "/YRECLDP_RCL_APB3", &yrecldp->rcl_apb3);  
+  read_hdf5(file_id, "/YRECLDP_RCL_AS", &yrecldp->rcl_as);  
+  read_hdf5(file_id, "/YRECLDP_RCL_BS", &yrecldp->rcl_bs);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CS", &yrecldp->rcl_cs);  
+  read_hdf5(file_id, "/YRECLDP_RCL_DS", &yrecldp->rcl_ds);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X1S", &yrecldp->rcl_x1s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X2S", &yrecldp->rcl_x2s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X3S", &yrecldp->rcl_x3s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X4S", &yrecldp->rcl_x4s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST1S", &yrecldp->rcl_const1s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST2S", &yrecldp->rcl_const2s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST3S", &yrecldp->rcl_const3s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST4S", &yrecldp->rcl_const4s);   
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST5S", &yrecldp->rcl_const5s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST6S", &yrecldp->rcl_const6s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST7S", &yrecldp->rcl_const7s);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST8S", &yrecldp->rcl_const8s);   
+  read_hdf5(file_id, "/YRECLDP_RDENSWAT", &yrecldp->rdenswat);  
+  read_hdf5(file_id, "/YRECLDP_RDENSREF", &yrecldp->rdensref);  
+  read_hdf5(file_id, "/YRECLDP_RCL_AR", &yrecldp->rcl_ar);  
+  read_hdf5(file_id, "/YRECLDP_RCL_BR", &yrecldp->rcl_br);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CR", &yrecldp->rcl_cr);  
+  read_hdf5(file_id, "/YRECLDP_RCL_DR", &yrecldp->rcl_dr);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X1R", &yrecldp->rcl_x1r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X2R", &yrecldp->rcl_x2r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_X4R", &yrecldp->rcl_x4r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_KA273", &yrecldp->rcl_ka273);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CDENOM1", &yrecldp->rcl_cdenom1);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CDENOM2", &yrecldp->rcl_cdenom2);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CDENOM3", &yrecldp->rcl_cdenom3);  
+  read_hdf5(file_id, "/YRECLDP_RCL_SCHMIDT", &yrecldp->rcl_schmidt);  
+  read_hdf5(file_id, "/YRECLDP_RCL_DYNVISC", &yrecldp->rcl_dynvisc);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST1R", &yrecldp->rcl_const1r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST2R", &yrecldp->rcl_const2r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST3R", &yrecldp->rcl_const3r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST4R", &yrecldp->rcl_const4r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_FAC1", &yrecldp->rcl_fac1);  
+  read_hdf5(file_id, "/YRECLDP_RCL_FAC2", &yrecldp->rcl_fac2);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST5R", &yrecldp->rcl_const5r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_CONST6R", &yrecldp->rcl_const6r);  
+  read_hdf5(file_id, "/YRECLDP_RCL_FZRAB", &yrecldp->rcl_fzrab);  
+  read_hdf5(file_id, "/YRECLDP_RCL_FZRBB", &yrecldp->rcl_fzrbb);
+  read_hdf5_int(file_id, "/YRECLDP_LCLDEXTRA", &yrecldp->lcldextra); // Bool
+  read_hdf5_int(file_id, "/YRECLDP_LCLDBUDGET", &yrecldp->lcldbudget); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_NSSOPT", &yrecldp->nssopt);   
+  read_hdf5_int(file_id, "/YRECLDP_NCLDTOP", &yrecldp->ncldtop);  
+  read_hdf5_int(file_id, "/YRECLDP_NAECLBC", &yrecldp->naeclbc);  
+  read_hdf5_int(file_id, "/YRECLDP_NAECLDU", &yrecldp->naecldu);  
+  read_hdf5_int(file_id, "/YRECLDP_NAECLOM", &yrecldp->naeclom);  
+  read_hdf5_int(file_id, "/YRECLDP_NAECLSS", &yrecldp->naeclss);  
+  read_hdf5_int(file_id, "/YRECLDP_NAECLSU", &yrecldp->naeclsu);  
+  read_hdf5_int(file_id, "/YRECLDP_NCLDDIAG", &yrecldp->nclddiag);  
+  read_hdf5_int(file_id, "/YRECLDP_NAERCLD", &yrecldp->naercld);  
+  read_hdf5_int(file_id, "/YRECLDP_LAERLIQAUTOLSP", &yrecldp->laerliqautolsp); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_LAERLIQAUTOCP", &yrecldp->laerliqautocp); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_LAERLIQAUTOCPB", &yrecldp->laerliqautocpb); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_LAERLIQCOLL", &yrecldp->laerliqcoll); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_LAERICESED", &yrecldp->laericesed); // Bool 
+  read_hdf5_int(file_id, "/YRECLDP_LAERICEAUTO", &yrecldp->laericeauto); // Bool 
+  read_hdf5(file_id, "/YRECLDP_NSHAPEP", &yrecldp->nshapep);  
+  read_hdf5(file_id, "/YRECLDP_NSHAPEQ", &yrecldp->nshapeq);  
+  read_hdf5_int(file_id, "/YRECLDP_NBETA", &yrecldp->nbeta);  
+  
+  status = H5Fclose(file_id);
+
+#endif
+
 }
+
+
 
 /* Read reference result into memory */
 void load_reference(const int nlon, const int nlev, const int nclv, const int ngptot, const int nproma,
@@ -364,12 +656,14 @@ void load_reference(const int nlon, const int nlev, const int nclv, const int ng
 		    double *pfsqltur, double *pfsqitur, double *pfplsl, double *pfplsn, double *pfhpsl, double *pfhpsn,
 		    double *tend_loc_a, double *tend_loc_q, double *tend_loc_t, double *tend_loc_cld)
 {
+
+  int nblocks = (ngptot / nproma) + min(ngptot % nproma, 1);
+
+#ifdef HAVE_SERIALBOX
   serialboxSerializer_t* serializer = serialboxSerializerCreate(Read, "./data", "reference", "Binary");
   serialboxMetainfo_t* metainfo = serialboxSerializerGetGlobalMetainfo(serializer);
   serialboxSavepoint_t** savepoints = serialboxSerializerGetSavepointVector(serializer);
   serialboxSavepoint_t* savepoint = savepoints[0];
-
-  int nblocks = (ngptot / nproma) + min(ngptot % nproma, 1);
 
   load_and_expand_2d(serializer, savepoint, "PLUDE", nlon, nlev, nproma, ngptot, nblocks, plude);
   load_and_expand_2d(serializer, savepoint, "PCOVPTOT", nlon, nlev, nproma, ngptot, nblocks, pcovptot);
@@ -395,4 +689,37 @@ void load_reference(const int nlon, const int nlev, const int nclv, const int ng
 
   serialboxSerializerDestroySavepointVector(savepoints, 1);
   serialboxSerializerDestroy(serializer);
+#endif
+
+#ifdef HAVE_HDF5
+
+  hid_t file_id, dataset_id;
+  herr_t  status;
+  file_id = H5Fopen(REFERENCE_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+
+  load_and_expand_2d(file_id, "PLUDE", nlon, nlev, nproma, ngptot, nblocks, plude);
+  load_and_expand_2d(file_id, "PCOVPTOT", nlon, nlev, nproma, ngptot, nblocks, pcovptot);
+  load_and_expand_1d(file_id, "PRAINFRAC_TOPRFZ", nlon, nproma, ngptot, nblocks, prainfrac_toprfz);
+  load_and_expand_2d(file_id, "PFSQLF", nlon, nlev+1, nproma, ngptot, nblocks, pfsqlf);
+  load_and_expand_2d(file_id, "PFSQIF", nlon, nlev+1, nproma, ngptot, nblocks, pfsqif);
+  load_and_expand_2d(file_id, "PFCQLNG", nlon, nlev+1, nproma, ngptot, nblocks, pfcqlng);
+  load_and_expand_2d(file_id, "PFCQNNG", nlon, nlev+1, nproma, ngptot, nblocks, pfcqnng);
+  load_and_expand_2d(file_id, "PFSQRF", nlon, nlev+1, nproma, ngptot, nblocks, pfsqrf);
+  load_and_expand_2d(file_id, "PFSQSF", nlon, nlev+1, nproma, ngptot, nblocks, pfsqsf);
+  load_and_expand_2d(file_id, "PFCQRNG", nlon, nlev+1, nproma, ngptot, nblocks, pfcqrng);
+  load_and_expand_2d(file_id, "PFCQSNG", nlon, nlev+1, nproma, ngptot, nblocks, pfcqsng);
+  load_and_expand_2d(file_id, "PFSQLTUR", nlon, nlev+1, nproma, ngptot, nblocks, pfsqltur);
+  load_and_expand_2d(file_id, "PFSQITUR", nlon, nlev+1, nproma, ngptot, nblocks, pfsqitur);
+  load_and_expand_2d(file_id, "PFPLSL", nlon, nlev+1, nproma, ngptot, nblocks, pfplsl);
+  load_and_expand_2d(file_id, "PFPLSN", nlon, nlev+1, nproma, ngptot, nblocks, pfplsn);
+  load_and_expand_2d(file_id, "PFHPSL", nlon, nlev+1, nproma, ngptot, nblocks, pfhpsl);
+  load_and_expand_2d(file_id, "PFHPSN", nlon, nlev+1, nproma, ngptot, nblocks, pfhpsn);
+  load_and_expand_2d(file_id, "TENDENCY_LOC_T", nlon, nlev, nproma, ngptot, nblocks, tend_loc_t);
+  load_and_expand_2d(file_id, "TENDENCY_LOC_Q", nlon, nlev, nproma, ngptot, nblocks, tend_loc_q);
+  load_and_expand_2d(file_id, "TENDENCY_LOC_A", nlon, nlev, nproma, ngptot, nblocks, tend_loc_a);
+  load_and_expand_3d(file_id, "TENDENCY_LOC_CLD", nlon, nlev, nclv, nproma, ngptot, nblocks, tend_loc_cld);
+
+  status = H5Fclose(file_id);
+#endif
+
 }


### PR DESCRIPTION
HDF5 support for CUDA/HIP/SYCL variants, similar to PR #62 ...

CUDA and SYCL tested on AC with NVHPC 22.11

HIP tested on LUMI ... **which gave me some problems, explaining why this is a draft PR ...**

* unable to find `hdf5.h`
* able to find `hdf5.h` removing `set(CMAKE_CXX_COMPILER "${ROCM_PATH}/bin/hipcc")`
    * removing this allows still compilation for the device (at least for CCE 16.01)
    * however, different problems with CCE 15.01
  
**tested a lot of different things, without any success in finding a solution that works for the different toolchains/cray-gpu versions**