### PR TITLE
Loki: Add yoecldp.F90 header that contains NCLV to fix SCC demotion

### DIFF
--- a/src/cloudsc_loki/CMakeLists.txt
+++ b/src/cloudsc_loki/CMakeLists.txt
@@ -453,7 +453,8 @@ if( HAVE_CLOUDSC_LOKI )
         FRONTEND ${LOKI_FRONTEND}
         SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}
-            ${COMMON_MODULE}
+	HEADERS
+            ${COMMON_MODULE}/yoecldp.F90
         INCLUDES
             ${COMMON_INCLUDE}
         XMOD
@@ -508,7 +509,8 @@ if( HAVE_CLOUDSC_LOKI )
         FRONTEND ${LOKI_FRONTEND}
         SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}
-            ${COMMON_MODULE}
+	HEADERS
+            ${COMMON_MODULE}/yoecldp.F90
         INCLUDES
             ${COMMON_INCLUDE}
         XMOD
@@ -569,7 +571,8 @@ if( HAVE_CLOUDSC_LOKI )
         FRONTEND ${LOKI_FRONTEND}
         SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}
-            ${COMMON_MODULE}
+	HEADERS
+            ${COMMON_MODULE}/yoecldp.F90
         INCLUDES
             ${COMMON_INCLUDE}
         XMOD


### PR DESCRIPTION
If Loki doesn't recognise NCLV as a parameter it will not demote the solver matrix arrays correctly.

@reuterbal This might be related to the last minute Scheduler changes, or might have been broken for a little while (not sure). However, with this in place, we get and the other Loki change we get equivalent performance between the respective "loki" and "gpu" variants again.