### PR TITLE
Loki: enable imports and mark headers as ignored instead of blocked

### DIFF
--- a/src/cloudsc_loki/cloudsc_cuf_loki.config
+++ b/src/cloudsc_loki/cloudsc_cuf_loki.config
@@ -9,7 +9,7 @@ enable_imports = true  # Chase dependencies incurred via imports
 # do not attempt to look up the source files for these.
 disable = [
     'timer_mod', 'abort', 'file_io_mod', 'foe*', 'fokoop',
-    'ceiling', 'dim3', 'cuda*'
+    'ceiling', 'dim3', 'cuda*', 'yoethf_cuf', 'yomcst_cuf',
 ]
 
 # Prune the tree for these to ensure they are not processed by transformations

--- a/src/cloudsc_loki/cloudsc_cuf_loki.config
+++ b/src/cloudsc_loki/cloudsc_cuf_loki.config
@@ -3,6 +3,7 @@
 role = 'kernel'
 expand = true  # Automatically expand subroutine calls
 strict = true  # Throw exceptions during dicovery
+enable_imports = true  # Chase dependencies incurred via imports
 
 # Ensure that we are never adding these to the tree, and thus
 # do not attempt to look up the source files for these.
@@ -12,7 +13,7 @@ disable = [
 ]
 
 # Prune the tree for these to ensure they are not processed by transformations
-block = ['parkind1', 'yomphyder', 'yoecldp', 'fc*_mod']
+ignore = ['parkind1', 'yomphyder', 'yoecldp', 'fc*_mod']
 
 # Define entry point for call-tree transformation
 [routines]

--- a/src/cloudsc_loki/cloudsc_loki.config
+++ b/src/cloudsc_loki/cloudsc_loki.config
@@ -3,13 +3,14 @@
 role = 'kernel'
 expand = true  # Automatically expand subroutine calls
 strict = true  # Throw exceptions during dicovery
+enable_imports = true  # Chase dependencies incurred via imports
 
 # Ensure that we are never adding these to the tree, and thus
 # do not attempt to look up the source files for these.
 disable = ['timer_mod', 'abort', 'file_io_mod', 'foe*', 'fokoop']
 
 # Prune the tree for these to ensure they are not processed by transformations
-block = ['parkind1', 'yomphyder', 'yoecldp', 'fc*_mod']
+ignore = ['parkind1', 'yomphyder', 'yoecldp', 'fc*_mod']
 
 # Define entry point for call-tree transformation
 [routines]


### PR DESCRIPTION
This is an alternative solution to #79.

* re-enables chasing import dependencies (after the last-minute default behaviour change in Loki) 
* fixes the problem that the header module defining `NCLV`, which is required for variable demotion, was marked as blocked and not ignored

Performance looks good with this, and demotion verified by diff'ing against the gpu_scc variant:

```
$ NV_ACC_CUDA_HEAPSIZE=6G bin/dwarf-cloudsc-loki-scc 1 163840 128
     NUMPROC=1, NUMOMP=1, NGPTOTG=163840, NPROMA=128, NGPBLKS=1280
 Reference MFLOP count for 100 columns :  12.48232900
     NUMOMP    NGPTOT  #GP-cols     #BLKS    NPROMA tid# : Time(msec)  MFlops/s     col/s
          1    163840    163840         1       128    0 :        105    194538   1558509 @ rank#0:core#172
          1    163840    163840      1280       128   -1 :       1613     12671    101518 : TOTAL @ rank#0
    1 x   1    163840    163840      1280       128   -1 :       1613     12671    101518 : TOTAL
...
$ bin/dwarf-cloudsc-loki-scc-hoist 1 163840 128
     NUMPROC=1, NUMOMP=1, NGPTOTG=163840, NPROMA=128, NGPBLKS=1280
 Reference MFLOP count for 100 columns :  12.48232900
     NUMOMP    NGPTOT  #GP-cols     #BLKS    NPROMA tid# : Time(msec)  MFlops/s     col/s
          1    163840    163840         1       128    0 :         62    329376   2638741 @ rank#0:core#172
          1    163840    163840      1280       128   -1 :       1573     12998    104134 : TOTAL @ rank#0
    1 x   1    163840    163840      1280       128   -1 :       1573     12998    104134 : TOTAL
...
$ bin/dwarf-cloudsc-loki-scc-stack 1 163840 128
     NUMPROC=1, NUMOMP=1, NGPTOTG=163840, NPROMA=128, NGPBLKS=1280
 Reference MFLOP count for 100 columns :  12.48232900
     NUMOMP    NGPTOT  #GP-cols     #BLKS    NPROMA tid# : Time(msec)  MFlops/s     col/s
          1    163840    163840         1       128    0 :         62    325949   2611287 @ rank#0:core#38
          1    163840    163840      1280       128   -1 :       1561     13096    104920 : TOTAL @ rank#0
    1 x   1    163840    163840      1280       128   -1 :       1561     13096    104920 : TOTAL
```