### PR TITLE
Ensure yoecldp.F90 is parsed with FParser

### DIFF
--- a/src/cloudsc_loki/cloudsc_loki.config
+++ b/src/cloudsc_loki/cloudsc_loki.config
@@ -49,3 +49,6 @@ frontend = 'FP'
 
 [frontend_args."yoethf.F90"]
 frontend = 'FP'
+
+[frontend_args."yoecldp.F90"]
+frontend = 'FP'


### PR DESCRIPTION
An annoying oversight: OMNI has become broken with v1.5.1 due to yoecldp.F90 being now parsed (it was on the block list previously) but the OMNI frontend segfaulting on it... Testing did not pick up on this, because CLOUDSC tests use only Fparser, and Loki regression wasn't tested against the configuration changes until after the release.

This PR ensures that file is always parsed with FParser