### PR TITLE
New SCC-RawStack pipeline and config from file

### DIFF
--- a/src/cloudsc_loki/CMakeLists.txt
+++ b/src/cloudsc_loki/CMakeLists.txt
@@ -540,6 +540,66 @@ if( HAVE_CLOUDSC_LOKI )
         OMP 1
     )
 
+    ############################################################
+    ##  "Single Column Coalesced" (SCC) mode with "raw stack" ##
+    ##   * Removes horizontal vector loops                    ##
+    ##   * Invokes compute kernel as `!$acc vector`           ##
+    ##   * Allocates temporaries using pool allocator         ##
+    ##   * Injects "stack" variables instead of pointers      ##
+    ############################################################
+
+    loki_transform(
+        COMMAND convert
+        OUTPUT
+            loki-scc-raw-stack/cloudsc.scc_raw_stack.F90
+            loki-scc-raw-stack/cloudsc_driver_loki_mod.scc_raw_stack.F90
+        BUILDDIR ${CMAKE_CURRENT_BINARY_DIR}/loki-scc-raw-stack
+        DEPENDS
+            cloudsc.F90
+            cloudsc_driver_loki_mod.F90
+            ${_OMNI_DEPENDENCIES}
+        MODE scc-raw-stack
+        CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/cloudsc_loki.config
+        CPP
+        DATA_OFFLOAD
+        REMOVE_OPENMP
+        DEFINITIONS
+            CLOUDSC_GPU_TIMING
+            ${CLOUDSC_DEFINE_STMT_FUNC}
+        FRONTEND ${LOKI_FRONTEND}
+        SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}
+            ${COMMON_MODULE}
+        INCLUDES
+            ${COMMON_INCLUDE}
+        XMOD
+            ${_TARGET_XMOD_DIR}
+            ${XMOD_DIR}
+    )
+
+    ecbuild_add_executable( TARGET dwarf-cloudsc-loki-scc-raw-stack
+        SOURCES
+            dwarf_cloudsc.F90
+            loki-scc-raw-stack/cloudsc_driver_loki_mod.scc_raw_stack.F90
+            loki-scc-raw-stack/cloudsc.scc_raw_stack.F90
+        LIBS
+            cloudsc-common-lib
+        DEFINITIONS ${CLOUDSC_DEFINITIONS}
+    )
+
+    if( CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+        target_compile_options( dwarf-cloudsc-loki-scc-raw-stack PRIVATE "-fcray-pointer" )
+    elseif( CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC" OR CMAKE_Fortran_COMPILER_ID MATCHES "PGI" )
+        target_compile_options( dwarf-cloudsc-loki-scc-raw-stack PRIVATE "-Mcray=pointer" )
+    endif()
+
+    ecbuild_add_test(
+        TARGET dwarf-cloudsc-loki-scc-raw-stack-serial
+        COMMAND bin/dwarf-cloudsc-loki-scc-raw-stack
+        ARGS 1 1280 128
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../..
+        OMP 1
+    )
 
     ####################################################
     ##  SCC-hoist mode                                ##

--- a/src/cloudsc_loki/cloudsc_cuf_loki.config
+++ b/src/cloudsc_loki/cloudsc_cuf_loki.config
@@ -53,7 +53,7 @@ expand = true
 # Please note that these are intended for eventual refactoring!
 [transformations.cuf-hoist]
   classname = 'SccCufTransformation'
-  module = 'transformations.scc_cuf'
+  module = 'loki.transformations.single_column'
 [transformations.cuf-hoist.options]
   transformation_type = 'hoist'
   horizontal = '%dimensions.horizontal%'
@@ -63,7 +63,7 @@ expand = true
 
 [transformations.cuf-dynamic]
   classname = 'SccCufTransformation'
-  module = 'transformations.scc_cuf'
+  module = 'loki.transformations.single_column'
 [transformations.cuf-dynamic.options]
   transformation_type = 'dynamic'
   horizontal = '%dimensions.horizontal%'
@@ -73,7 +73,7 @@ expand = true
 
 [transformations.cuf-parametrise]
   classname = 'SccCufTransformation'
-  module = 'transformations.scc_cuf'
+  module = 'loki.transformations.single_column'
 [transformations.cuf-parametrise.options]
   transformation_type = 'parametrise'
   horizontal = '%dimensions.horizontal%'
@@ -84,5 +84,5 @@ expand = true
 # For SCC-CUF-parametrise we need to define the
 # in-source replacement via "dic2p".
 [transformations.ParametriseTransformation]
-  module = 'loki.transform'
+  module = 'loki.transformations'
   options = { dic2p = {NLEV = 137} }

--- a/src/cloudsc_loki/cloudsc_loki.config
+++ b/src/cloudsc_loki/cloudsc_loki.config
@@ -52,3 +52,47 @@ frontend = 'FP'
 
 [frontend_args."yoecldp.F90"]
 frontend = 'FP'
+
+# Define specific transformation settings
+[transformations]
+
+# Loki-SCC family
+# -----------------------------------------
+
+[transformations.scc]
+  classname = 'SCCVectorPipeline'
+  module = 'loki.transformations.single_column'
+[transformations.scc.options]
+  horizontal = '%dimensions.horizontal%'
+  block_dim = '%dimensions.block_dim%'
+  directive = 'openacc'
+
+
+[transformations.scc-hoist]
+  classname = 'SCCHoistPipeline'
+  module = 'loki.transformations.single_column'
+[transformations.scc-hoist.options]
+  horizontal = '%dimensions.horizontal%'
+  block_dim = '%dimensions.block_dim%'
+  directive = 'openacc'
+
+
+[transformations.scc-stack]
+  classname = 'SCCStackPipeline'
+  module = 'loki.transformations.single_column'
+[transformations.scc-stack.options]
+  horizontal = '%dimensions.horizontal%'
+  block_dim = '%dimensions.block_dim%'
+  directive = 'openacc'
+  check_bounds = false
+
+
+[transformations.scc-raw-stack]
+  classname = 'SCCRawStackPipeline'
+  module = 'loki.transformations.single_column'
+[transformations.scc-raw-stack.options]
+  horizontal = '%dimensions.horizontal%'
+  block_dim = '%dimensions.block_dim%'
+  directive = 'openacc'
+  check_bounds = false
+  driver_horizontal = 'NPROMA'


### PR DESCRIPTION
This PR adds a new SCC variant for the Loki-SCC family, as contributed from DestinE partners. It adds the new variant, and specific config-file configurations for our main SCC-family pipelines. The reason these come together is that one of the overrides for `scc-raw-stack` is specific to CLOUDSC conventions, and should not go into defaults in `loki-transform.py`.

I've also updated the paths for the SCC-CUF transformtations in the other config file, which had become out-of-date.

Please also note that, while this is a first step towards fully config-file based setups, there is more to be done, so I'm not aiming for full "from file configuration" just yet. :wink: 