### PR TITLE
Use single precision math functions for CUDA variants

### DIFF
--- a/src/cloudsc_cuda/cloudsc/dtype.h
+++ b/src/cloudsc_cuda/cloudsc/dtype.h
@@ -24,10 +24,10 @@ typedef double dtype;
 
 #define MYMAX(x,y) fmaxf(x,y)
 #define MYMIN(x,y) fminf(x,y)
-#define MYEXP(x) exp(x)
-#define MYPOW(x,y) pow(x,y)
-#define MYPOWN(x,y) pow(x,y)
-#define MYABS(x) fabs(x)
+#define MYEXP(x) expf(x)
+#define MYPOW(x,y) powf(x,y)
+#define MYPOWN(x,y) powf(x,y)
+#define MYABS(x) fabsf(x)
 
 #else
 


### PR DESCRIPTION
Use single precision math functions for CUDA variants when compiling for single precision, thus:

* `pow` -> `powf`
* `fabs` -> `fabsf`