### PR TITLE
Loki: C transpilation from pipeline in config file

### DIFF
--- a/src/cloudsc_loki/cloudsc_loki.config
+++ b/src/cloudsc_loki/cloudsc_loki.config
@@ -23,10 +23,6 @@ enable_imports = true  # Chase dependencies incurred via imports
 # do not attempt to look up the source files for these.
 disable = ['timer_mod', 'abort', 'file_io_mod', 'foe*', 'fokoop']
 
-# Prune these moduels from the treeto ensure they are not processed by
-# transformations
-ignore = ['parkind1', 'yomphyder', 'yoecldp', 'fc*_mod']
-
 
 # Call tree entry points ("driver" subroutines)
 # -------------------------------------------------------------------
@@ -40,6 +36,28 @@ ignore = ['parkind1', 'yomphyder', 'yoecldp', 'fc*_mod']
 [routines.cloudsc_driver]
   role = 'driver'
   expand = true
+
+# Explicitly marked "header" modules needed by the C transpilation
+# -------------------------------------------------------------------
+[routines.yoethf]
+  role = 'header'
+  expand = false
+
+[routines.yomcst]
+  role = 'header'
+  expand = false
+
+[routines.yoecldp]
+  role = 'header'
+  expand = false
+
+[routines.yomphyder]
+  role = 'header'
+  expand = false
+
+[routines.parkind1]
+  role = 'header'
+  expand = false
 
 
 # Configuration of "Dimension" variables
@@ -125,16 +143,25 @@ preprocess = true
   check_bounds = true
 
 
-[transformations.InlineTransformation]
+[transformations.Inline]
   classname = 'InlineTransformation'
   module = 'loki.transformations'
-[transformations.InlineTransformation.options]
+[transformations.Inline.options]
   inline_internals = false
   inline_marked = true
   inline_stmt_funcs = true
   remove_dead_code = true
   allowed_aliases = 'JL'
   resolve_sequence_association = false
+
+
+[transformations.FortranToC]
+  classname = 'FortranCTransformation'
+  module = 'loki.transformations.transpile'
+
+[transformations.FortranISOCWrapper]
+  classname = 'FortranISOCWrapperTransformation'
+  module = 'loki.transformations.transpile'
 
 
 # Loki-SCC family of transformations
@@ -195,6 +222,11 @@ preprocess = true
   module = 'loki.transformations.build_system'
   options = { suffix = '_LOKI', module_suffix = '_MOD' }
 
+[transformations.Dependency_CToF]
+  classname = 'DependencyTransformation'
+  module = 'loki.transformations.build_system'
+  options = { suffix = '_FC', module_suffix = '_MOD' }
+
 
 # Full transformation pipelines
 # -------------------------------------------------------------------
@@ -226,3 +258,6 @@ preprocess = true
 
 [pipelines.scc-stack]
   transformations = ['DataOffload', 'Sanitise', 'SCCStack', 'ModuleWrap', 'Dependency']
+
+[pipelines.c]
+  transformations = ['Sanitise', 'Inline', 'FortranToC', 'FortranISOCWrapper', 'ModuleWrap', 'Dependency_CToF']


### PR DESCRIPTION
This PR adds a new C-transpilation pipeline to the Loki configuration file that replaces the previous use of the implicit entry point for the `FortranCTransformation` in `loki-transform.py convert`. It does this by adding a new entry for the `FortranISOCWrapperTransformation` and marking the corresponding modules with `"header"` roles.

Integration note: This PR requires Loki PR #464 (https://github.com/ecmwf-ifs/loki/pull/464) to be merged first, and currently points to this branch in a temporary head commit that should be removed before merging. 