### PR TITLE
HDF5 file access rights

### DIFF
--- a/src/cloudsc_c/cloudsc/load_state.c
+++ b/src/cloudsc_c/cloudsc/load_state.c
@@ -57,7 +57,7 @@ void query_state(int *klon, int *klev)
 #ifdef HAVE_HDF5
   hid_t file_id, dataset_id;
   herr_t  status;
-  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDONLY, H5P_DEFAULT);
   
   read_hdf5_int(file_id, "/KLEV", klev);
   read_hdf5_int(file_id, "/KLON", klon);
@@ -496,7 +496,7 @@ void load_state(const int nlon, const int nlev, const int nclv, const int ngptot
 
   hid_t file_id, dataset_id;
   herr_t  status;
-  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDONLY, H5P_DEFAULT);
 
   load_and_expand_2d(file_id, "PLCRIT_AER", nlon, nlev, nproma, ngptot, nblocks, plcrit_aer);
   load_and_expand_2d(file_id, "PICRIT_AER", nlon, nlev, nproma, ngptot, nblocks, picrit_aer);
@@ -743,7 +743,7 @@ void load_reference(const int nlon, const int nlev, const int nclv, const int ng
 
   hid_t file_id, dataset_id;
   herr_t  status;
-  file_id = H5Fopen(REFERENCE_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+  file_id = H5Fopen(REFERENCE_FILE, H5F_ACC_RDONLY, H5P_DEFAULT);
 
   load_and_expand_2d(file_id, "PLUDE", nlon, nlev, nproma, ngptot, nblocks, plude);
   load_and_expand_2d(file_id, "PCOVPTOT", nlon, nlev, nproma, ngptot, nblocks, pcovptot);

--- a/src/cloudsc_cuda/cloudsc/load_state.cu
+++ b/src/cloudsc_cuda/cloudsc/load_state.cu
@@ -59,7 +59,7 @@ void query_state(int *klon, int *klev)
 #ifdef HAVE_HDF5
   hid_t file_id, dataset_id;
   herr_t  status;
-  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDONLY, H5P_DEFAULT);
 
   read_hdf5_int(file_id, "/KLEV", klev);
   read_hdf5_int(file_id, "/KLON", klon);
@@ -492,7 +492,7 @@ void load_state(const int nlon, const int nlev, const int nclv, const int ngptot
 
   hid_t file_id, dataset_id;
   herr_t  status;
-  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDONLY, H5P_DEFAULT);
 
   load_and_expand_2d(file_id, "PLCRIT_AER", nlon, nlev, nproma, ngptot, nblocks, plcrit_aer);
   load_and_expand_2d(file_id, "PICRIT_AER", nlon, nlev, nproma, ngptot, nblocks, picrit_aer);
@@ -739,7 +739,7 @@ void load_reference(const int nlon, const int nlev, const int nclv, const int ng
 
   hid_t file_id, dataset_id;
   herr_t  status;
-  file_id = H5Fopen(REFERENCE_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+  file_id = H5Fopen(REFERENCE_FILE, H5F_ACC_RDONLY, H5P_DEFAULT);
 
   load_and_expand_2d(file_id, "PLUDE", nlon, nlev, nproma, ngptot, nblocks, plude);
   load_and_expand_2d(file_id, "PCOVPTOT", nlon, nlev, nproma, ngptot, nblocks, pcovptot);

--- a/src/cloudsc_hip/cloudsc/load_state.cpp
+++ b/src/cloudsc_hip/cloudsc/load_state.cpp
@@ -60,7 +60,7 @@ void query_state(int *klon, int *klev)
 #ifdef HAVE_HDF5
   hid_t file_id, dataset_id;
   herr_t  status;
-  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDONLY, H5P_DEFAULT);
 
   read_hdf5_int(file_id, "/KLEV", klev);
   read_hdf5_int(file_id, "/KLON", klon);
@@ -490,7 +490,7 @@ void load_state(const int nlon, const int nlev, const int nclv, const int ngptot
 
   hid_t file_id, dataset_id;
   herr_t  status;
-  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDONLY, H5P_DEFAULT);
 
   load_and_expand_2d(file_id, "PLCRIT_AER", nlon, nlev, nproma, ngptot, nblocks, plcrit_aer);
   load_and_expand_2d(file_id, "PICRIT_AER", nlon, nlev, nproma, ngptot, nblocks, picrit_aer);
@@ -733,7 +733,7 @@ void load_reference(const int nlon, const int nlev, const int nclv, const int ng
 
   hid_t file_id, dataset_id;
   herr_t  status;
-  file_id = H5Fopen(REFERENCE_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+  file_id = H5Fopen(REFERENCE_FILE, H5F_ACC_RDONLY, H5P_DEFAULT);
 
   load_and_expand_2d(file_id, "PLUDE", nlon, nlev, nproma, ngptot, nblocks, plude);
   load_and_expand_2d(file_id, "PCOVPTOT", nlon, nlev, nproma, ngptot, nblocks, pcovptot);

--- a/src/cloudsc_sycl/cloudsc/load_state.cpp
+++ b/src/cloudsc_sycl/cloudsc/load_state.cpp
@@ -60,7 +60,7 @@ void query_state(int *klon, int *klev)
 #ifdef HAVE_HDF5
   hid_t file_id, dataset_id;
   herr_t  status;
-  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDONLY, H5P_DEFAULT);
 
   read_hdf5_int(file_id, "/KLEV", klev);
   read_hdf5_int(file_id, "/KLON", klon);
@@ -490,7 +490,7 @@ void load_state(const int nlon, const int nlev, const int nclv, const int ngptot
 
   hid_t file_id, dataset_id;
   herr_t  status;
-  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+  file_id = H5Fopen(INPUT_FILE, H5F_ACC_RDONLY, H5P_DEFAULT);
 
   load_and_expand_2d(file_id, "PLCRIT_AER", nlon, nlev, nproma, ngptot, nblocks, plcrit_aer);
   load_and_expand_2d(file_id, "PICRIT_AER", nlon, nlev, nproma, ngptot, nblocks, picrit_aer);
@@ -733,7 +733,7 @@ void load_reference(const int nlon, const int nlev, const int nclv, const int ng
 
   hid_t file_id, dataset_id;
   herr_t  status;
-  file_id = H5Fopen(REFERENCE_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+  file_id = H5Fopen(REFERENCE_FILE, H5F_ACC_RDONLY, H5P_DEFAULT);
 
   load_and_expand_2d(file_id, "PLUDE", nlon, nlev, nproma, ngptot, nblocks, plude);
   load_and_expand_2d(file_id, "PCOVPTOT", nlon, nlev, nproma, ngptot, nblocks, pcovptot);


### PR DESCRIPTION
Some of the HDF5-related functions request more rights than necessary in sections that only read the state. This PR adjusts the rights in the corresponding `H5Fopen` function calls.

While it is not fundamentally wrong to request RDWR access here, HDF5 applies a file lock in this case, which can lead to errors if multiple of the cloudsc prototypes are run simultaneously, for example in a benchmark setting. The lock-induced errors look like this:

```
[...]
HDF5-DIAG: Error detected in HDF5 (1.14.3) thread 0:
  #000: [...]/src/H5F.c line 836 in H5Fopen(): unable to synchronously open file
    major: File accessibility
    minor: Unable to open file
[...]
```

Note that file locking can also be disabled altogether by setting the environment variable `HDF5_USE_FILE_LOCKING=FALSE`,  but users might not be aware of this option.

The changes were tested locally, without any trouble.