### PR TITLE
Bugfix: Remove zeroing of fields inside driver for FIELD API CPU variants

### DIFF
--- a/src/cloudsc_fortran/cloudsc_driver_field_mod.F90
+++ b/src/cloudsc_fortran/cloudsc_driver_field_mod.F90
@@ -69,12 +69,6 @@ CONTAINS
         CALL FLUX%UPDATE_VIEW(IBL)
         CALL TENDENCY_LOC%UPDATE_VIEW(IBL)
         CALL TENDENCY_TMP%UPDATE_VIEW(IBL)
-        
-        !-- These were uninitialized : meaningful only when we compare error differences
-        PAUX%PCOVPTOT = 0.0_JPRB
-        TENDENCY_LOC%CLD(:,:,NCLV) = 0.0_JPRB
-
-
 
         CALL CLOUDSC(    1,    ICEND,    NPROMA,  NLEV, & ! These could also be accessed through FIELD_STATE
               & PTSPHY,&

--- a/src/cloudsc_loki/cloudsc_driver_field_loki_mod.F90
+++ b/src/cloudsc_loki/cloudsc_driver_field_loki_mod.F90
@@ -79,12 +79,6 @@ CONTAINS
         CALL TENDENCY_LOC%UPDATE_VIEW(IBL)
         CALL TENDENCY_TMP%UPDATE_VIEW(IBL)
 
-        !-- These were uninitialized : meaningful only when we compare error differences
-        PAUX%PCOVPTOT = 0.0_JPRB
-        TENDENCY_LOC%CLD(:,:,NCLV) = 0.0_JPRB
-
-
-
         CALL CLOUDSC(    1,    ICEND,    NPROMA,  NLEV, & ! These could also be accessed through FIELD_STATE
               & PTSPHY,&
               & PAUX%PT, PAUX%PQ, &


### PR DESCRIPTION
This is a simple bug fix PR that fixes an error in the output of the FIELD API CPU variant.  This PR removes zeroing of ``PAUX%PCOVTOT`` and ``TENDENCY_LOC%CLD`` inside the driver loop as it led to errors in the cloudsc output. The fields are already initialised to zero in the respective state types and need not be initialised inside the driver.