### PR TITLE
common: Add PP guard around OMP TARGET directives

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -159,6 +159,8 @@ if( HAVE_OMP AND HAVE_OMP_TARGET )
     cloudsc_add_common_lib(
         SUFFIX omp
         TYPE ${GPU_LINK_TYPE}
+        DEFINITIONS
+            HAVE_OMP_TARGET
         LIBS
             OpenMP::OpenMP_Fortran
     )

--- a/src/common/module/yoethf.F90
+++ b/src/common/module/yoethf.F90
@@ -48,7 +48,7 @@ REAL(KIND=JPRB) :: RKOOP2
 !$acc declare copyin(r2es, r3les, r3ies, r4les, r4ies, r5les, r5ies, &
 !$acc   r5alvcp, r5alscp, ralvdcp, ralsdcp, ralfdcp, rtwat, rtice, rticecu, &
 !$acc   rtwat_rtice_r, rtwat_rticecu_r, rkoop1, rkoop2)
-#else
+#elif defined(HAVE_OMP_TARGET)
 !$omp declare target(r2es, r3les, r3ies, r4les, r4ies, r5les, r5ies, &
 !$omp&  r5alvcp, r5alscp, ralvdcp, ralsdcp, ralfdcp, rtwat, rtice, rticecu, &
 !$omp&  rtwat_rtice_r, rtwat_rticecu_r, rkoop1, rkoop2)
@@ -135,7 +135,7 @@ CONTAINS
 !$acc update device(r2es, r3les, r3ies, r4les, r4ies, r5les, r5ies, &
 !$acc   r5alvcp, r5alscp, ralvdcp, ralsdcp, ralfdcp, rtwat, rtice, rticecu, &
 !$acc   rtwat_rtice_r, rtwat_rticecu_r, rkoop1, rkoop2)
-#else
+#elif defined(HAVE_OMP_TARGET)
 !$omp target update to(r2es, r3les, r3ies, r4les, r4ies, r5les, r5ies, &
 !$omp&   r5alvcp, r5alscp, ralvdcp, ralsdcp, ralfdcp, rtwat, rtice, rticecu, &
 !$omp&   rtwat_rtice_r, rtwat_rticecu_r, rkoop1, rkoop2)

--- a/src/common/module/yomcst.F90
+++ b/src/common/module/yomcst.F90
@@ -160,7 +160,7 @@ REAL(KIND=JPRB) :: RSNAN
 
 #ifdef _OPENACC
 !$acc declare copyin(rg, rd, rcpd, retv, rlvtt, rlstt, rlmlt, rtt, rv)
-#else
+#elif defined(HAVE_OMP_TARGET)
 !$omp declare target(rg, rd, rcpd, retv, rlvtt, rlstt, rlmlt, rtt, rv)
 #endif
 
@@ -324,7 +324,7 @@ CONTAINS
     CALL YRCST_COPY_PARAMETERS()
 #ifdef _OPENACC
 !$acc update device(rg, rd, rcpd, retv, rlvtt, rlstt, rlmlt, rtt, rv)
-#else
+#elif defined(HAVE_OMP_TARGET)
 !$omp target update to(rg, rd, rcpd, retv, rlvtt, rlstt, rlmlt, rtt, rv)
 #endif
   END SUBROUTINE YOMCST_LOAD_PARAMETERS


### PR DESCRIPTION
This should fix compilation with LLVM 20 by not exposing the OpenMP directives unless we have detected compiler support for OpenMP target.

Thanks to @antoine-morvan for reporting this.